### PR TITLE
perf(amm): speed up swap hot path via bitmask tick scan, inlining, and caching

### DIFF
--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -829,6 +829,8 @@ pub fn swap_on_swap_state(
 
     // Hot-path precomputations to avoid repeated work in the loop
     let tick_spacing = pool_state.tick_spacing;
+    let tick_spacing_i32: i32 = i32::from(tick_spacing);
+    let ticks_per_array: i32 = crate::states::tick_array::TICK_ARRAY_SIZE * tick_spacing_i32;
     let has_protocol_fee = amm_config.protocol_fee_rate > 0;
     let has_fund_fee = amm_config.fund_fee_rate > 0;
     let denom_u128 = U128::from(FEE_RATE_DENOMINATOR_VALUE);
@@ -837,9 +839,13 @@ pub fn swap_on_swap_state(
     let protocol_rate_u128 = U128::from(amm_config.protocol_fee_rate);
     let fund_rate_u128 = U128::from(amm_config.fund_fee_rate);
 
+    let mut cached_tick_next: i32 = i32::MIN;
+    let mut cached_sqrt_price_next_x64: u128 = 0;
+
     let mut tick_array_current = tick_array_states
         .pop_front()
         .ok_or(ErrorCode::InvalidTickArrayBoundary)?;
+    let mut current_start = tick_array_current.start_tick_index;
     // check tick_array account is owned by the pool
     // require_keys_eq!(tick_array_current.pool_id, pool_state.key());
 
@@ -885,6 +891,9 @@ pub fn swap_on_swap_state(
     // This allows O(1) bit scans instead of O(60) linear scans per step.
     #[inline(always)]
     fn build_initialized_mask(tick_array: &TickArrayState) -> u64 {
+        if tick_array.initialized_tick_count == 0 {
+            return 0;
+        }
         let mut mask: u64 = 0;
         let mut i: usize = 0;
         while i < crate::states::tick_array::TICK_ARRAY_SIZE_USIZE {
@@ -896,8 +905,8 @@ pub fn swap_on_swap_state(
         mask
     }
 
-    let tick_spacing_i32: i32 = i32::from(tick_spacing);
     let mut current_array_mask: u64 = build_initialized_mask(tick_array_current);
+    let mut liquidity_u128 = U128::from(state.liquidity);
 
     while state.amount_specified_remaining != 0 && state.sqrt_price_x64 != sqrt_price_limit_x64 {
         #[cfg(feature = "enable-log")]
@@ -920,50 +929,54 @@ pub fn swap_on_swap_state(
         step.sqrt_price_start_x64 = state.sqrt_price_x64;
 
         // Fast path: locate next initialized tick using bit scans within the current array.
-        let mut next_initialized_tick = {
-            let current_start = tick_array_current.start_tick_index;
-            if TickArrayState::get_array_start_index(state.tick, tick_spacing) != current_start {
-                None
-            } else {
-                let mut offset_in_array = (state.tick - current_start) / tick_spacing_i32;
-                if zero_for_one {
-                    if offset_in_array < 0 {
-                        offset_in_array = 0;
-                    } else if offset_in_array >= crate::states::tick_array::TICK_ARRAY_SIZE {
-                        offset_in_array = crate::states::tick_array::TICK_ARRAY_SIZE - 1;
-                    }
-                    let upto = (offset_in_array as u32).saturating_add(1);
-                    let search_mask = if upto >= 64 {
-                        current_array_mask
-                    } else {
-                        current_array_mask & ((1u64 << upto) - 1)
-                    };
-                    if search_mask != 0 {
-                        let idx = 63u32.saturating_sub(search_mask.leading_zeros());
-                        Some(&tick_array_current.ticks[idx as usize])
-                    } else {
-                        None
-                    }
+        let mut chosen_idx_for_mask: Option<u32> = None;
+        let array_upper_bound = current_start.saturating_add(ticks_per_array);
+        let mut next_initialized_tick = if current_array_mask == 0
+            || state.tick < current_start
+            || state.tick >= array_upper_bound
+        {
+            None
+        } else {
+            let mut offset_in_array = (state.tick - current_start) / tick_spacing_i32;
+            if zero_for_one {
+                if offset_in_array < 0 {
+                    offset_in_array = 0;
+                } else if offset_in_array >= crate::states::tick_array::TICK_ARRAY_SIZE {
+                    offset_in_array = crate::states::tick_array::TICK_ARRAY_SIZE - 1;
+                }
+                let upto = (offset_in_array as u32).saturating_add(1);
+                let search_mask = if upto >= 64 {
+                    current_array_mask
                 } else {
-                    let mut start_bit = offset_in_array + 1;
-                    if start_bit < 0 {
-                        start_bit = 0;
-                    } else if start_bit > crate::states::tick_array::TICK_ARRAY_SIZE {
-                        start_bit = crate::states::tick_array::TICK_ARRAY_SIZE;
-                    }
-                    let search_mask = if start_bit >= 64 {
-                        0u64
-                    } else if start_bit <= 0 {
-                        current_array_mask
-                    } else {
-                        current_array_mask & (!((1u64 << (start_bit as u32)) - 1))
-                    };
-                    if search_mask != 0 {
-                        let idx = search_mask.trailing_zeros();
-                        Some(&tick_array_current.ticks[idx as usize])
-                    } else {
-                        None
-                    }
+                    current_array_mask & ((1u64 << upto) - 1)
+                };
+                if search_mask != 0 {
+                    let idx = 63u32 - search_mask.leading_zeros();
+                    chosen_idx_for_mask = Some(idx);
+                    Some(&tick_array_current.ticks[idx as usize])
+                } else {
+                    None
+                }
+            } else {
+                let mut start_bit = offset_in_array + 1;
+                if start_bit < 0 {
+                    start_bit = 0;
+                } else if start_bit > crate::states::tick_array::TICK_ARRAY_SIZE {
+                    start_bit = crate::states::tick_array::TICK_ARRAY_SIZE;
+                }
+                let search_mask = if start_bit >= 64 {
+                    0u64
+                } else if start_bit <= 0 {
+                    current_array_mask
+                } else {
+                    current_array_mask & (!((1u64 << (start_bit as u32)) - 1))
+                };
+                if search_mask != 0 {
+                    let idx = search_mask.trailing_zeros();
+                    chosen_idx_for_mask = Some(idx);
+                    Some(&tick_array_current.ticks[idx as usize])
+                } else {
+                    None
                 }
             }
         };
@@ -971,10 +984,19 @@ pub fn swap_on_swap_state(
             next_initialized_tick = if let Some(tick_state) =
                 tick_array_current.next_initialized_tick(state.tick, tick_spacing, zero_for_one)?
             {
+                let idx_calc = (tick_state.tick - current_start) / tick_spacing_i32;
+                if idx_calc >= 0 && idx_calc < crate::states::tick_array::TICK_ARRAY_SIZE {
+                    chosen_idx_for_mask = Some(idx_calc as u32);
+                }
                 Some(tick_state)
             } else if !is_match_pool_current_tick_array {
                 is_match_pool_current_tick_array = true;
-                Some(tick_array_current.first_initialized_tick(zero_for_one)?)
+                let first = tick_array_current.first_initialized_tick(zero_for_one)?;
+                let idx_calc = (first.tick - current_start) / tick_spacing_i32;
+                if idx_calc >= 0 && idx_calc < crate::states::tick_array::TICK_ARRAY_SIZE {
+                    chosen_idx_for_mask = Some(idx_calc as u32);
+                }
+                Some(first)
             } else {
                 None
             };
@@ -1000,6 +1022,7 @@ pub fn swap_on_swap_state(
             tick_array_current = tick_array_states
                 .pop_front()
                 .ok_or(ErrorCode::InvalidTickArrayBoundary)?;
+            current_start = tick_array_current.start_tick_index;
             // Recompute the mask for the new array
             current_array_mask = build_initialized_mask(tick_array_current);
 
@@ -1024,6 +1047,12 @@ pub fn swap_on_swap_state(
 
             let first_initialized_tick = tick_array_current.first_initialized_tick(zero_for_one)?;
             next_initialized_tick = first_initialized_tick;
+            let idx_calc = (first_initialized_tick.tick - current_start) / tick_spacing_i32;
+            if idx_calc >= 0 && idx_calc < crate::states::tick_array::TICK_ARRAY_SIZE {
+                chosen_idx_for_mask = Some(idx_calc as u32);
+            } else {
+                chosen_idx_for_mask = None;
+            }
         }
         step.tick_next = next_initialized_tick.tick;
         step.initialized = next_initialized_tick.is_initialized();
@@ -1033,7 +1062,11 @@ pub fn swap_on_swap_state(
         } else if step.tick_next > tick_math::MAX_TICK {
             step.tick_next = tick_math::MAX_TICK;
         }
-        step.sqrt_price_next_x64 = tick_math::get_sqrt_price_at_tick(step.tick_next)?;
+        if cached_tick_next != step.tick_next {
+            cached_tick_next = step.tick_next;
+            cached_sqrt_price_next_x64 = tick_math::get_sqrt_price_at_tick(step.tick_next)?;
+        }
+        step.sqrt_price_next_x64 = cached_sqrt_price_next_x64;
 
         let target_price = if (zero_for_one && step.sqrt_price_next_x64 < sqrt_price_limit_x64)
             || (!zero_for_one && step.sqrt_price_next_x64 > sqrt_price_limit_x64)
@@ -1150,7 +1183,7 @@ pub fn swap_on_swap_state(
         // update global fee tracker
         if state.liquidity > 0 {
             let fee_growth_global_x64_delta = U128::from(step.fee_amount)
-                .mul_div_floor(q64_u128, U128::from(state.liquidity))
+                .mul_div_floor(q64_u128, liquidity_u128)
                 .ok_or(ErrorCode::CalculateOverflow)?
                 .as_u128();
 
@@ -1188,6 +1221,10 @@ pub fn swap_on_swap_state(
                     liquidity_net = liquidity_net.neg();
                 }
                 state.liquidity = liquidity_math::add_delta(state.liquidity, liquidity_net)?;
+                liquidity_u128 = U128::from(state.liquidity);
+                if let Some(bit_idx) = chosen_idx_for_mask {
+                    current_array_mask &= !(1u64 << bit_idx);
+                }
             }
 
             state.tick = if zero_for_one {

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -189,7 +189,7 @@ pub fn swap_internal<'b, 'info>(
     require_keys_eq!(observation_state.pool_id, pool_state.key());
 
     let (mut is_match_pool_current_tick_array, first_vaild_tick_array_start_index) =
-        pool_state.get_first_initialized_tick_array(&tickarray_bitmap_extension, zero_for_one)?;
+        pool_state.get_first_initialized_tick_array(tickarray_bitmap_extension, zero_for_one)?;
     let mut current_vaild_tick_array_start_index = first_vaild_tick_array_start_index;
 
     let mut tick_array_current = tick_array_states.pop_front().unwrap();
@@ -213,6 +213,10 @@ pub fn swap_internal<'b, 'info>(
 
     // continue swapping as long as we haven't used the entire input/output and haven't
     // reached the price limit
+    // Cache sqrt(price) for the current step.tick_next to avoid repeated tick->price conversions
+    let mut cached_tick_next: i32 = i32::MIN;
+    let mut cached_sqrt_price_next_x64: u128 = 0;
+
     while state.amount_specified_remaining != 0 && state.sqrt_price_x64 != sqrt_price_limit_x64 {
         #[cfg(feature = "enable-log")]
         msg!(
@@ -237,13 +241,11 @@ pub fn swap_internal<'b, 'info>(
             .next_initialized_tick(state.tick, pool_state.tick_spacing, zero_for_one)?
         {
             Box::new(*tick_state)
+        } else if !is_match_pool_current_tick_array {
+            is_match_pool_current_tick_array = true;
+            Box::new(*tick_array_current.first_initialized_tick(zero_for_one)?)
         } else {
-            if !is_match_pool_current_tick_array {
-                is_match_pool_current_tick_array = true;
-                Box::new(*tick_array_current.first_initialized_tick(zero_for_one)?)
-            } else {
-                Box::new(TickState::default())
-            }
+            Box::new(TickState::default())
         };
         #[cfg(feature = "enable-log")]
         msg!(
@@ -255,7 +257,7 @@ pub fn swap_internal<'b, 'info>(
         if !next_initialized_tick.is_initialized() {
             let next_initialized_tickarray_index = pool_state
                 .next_initialized_tick_array_start_index(
-                    &tickarray_bitmap_extension,
+                    tickarray_bitmap_extension,
                     current_vaild_tick_array_start_index,
                     zero_for_one,
                 )?;
@@ -283,7 +285,11 @@ pub fn swap_internal<'b, 'info>(
         } else if step.tick_next > tick_math::MAX_TICK {
             step.tick_next = tick_math::MAX_TICK;
         }
-        step.sqrt_price_next_x64 = tick_math::get_sqrt_price_at_tick(step.tick_next)?;
+        if cached_tick_next != step.tick_next {
+            cached_tick_next = step.tick_next;
+            cached_sqrt_price_next_x64 = tick_math::get_sqrt_price_at_tick(step.tick_next)?;
+        }
+        step.sqrt_price_next_x64 = cached_sqrt_price_next_x64;
 
         let target_price = if (zero_for_one && step.sqrt_price_next_x64 < sqrt_price_limit_x64)
             || (!zero_for_one && step.sqrt_price_next_x64 > sqrt_price_limit_x64)
@@ -423,7 +429,7 @@ pub fn swap_internal<'b, 'info>(
                 // update tick_state to tick_array account
                 tick_array_current.update_tick_state(
                     next_initialized_tick.tick,
-                    pool_state.tick_spacing.into(),
+                    pool_state.tick_spacing,
                     *next_initialized_tick,
                 )?;
 
@@ -603,7 +609,7 @@ pub fn exact_internal<'b, 'c: 'info, 'info>(
         tick_array_states.push_back(ctx.tick_array_state.load_mut()?);
 
         let tick_array_bitmap_extension_key = TickArrayBitmapExtension::key(pool_state.key());
-        for account_info in remaining_accounts.into_iter() {
+        for account_info in remaining_accounts.iter() {
             if account_info.key().eq(&tick_array_bitmap_extension_key) {
                 tickarray_bitmap_extension = Some(
                     *(AccountLoader::<TickArrayBitmapExtension>::try_from(account_info)?
@@ -616,7 +622,7 @@ pub fn exact_internal<'b, 'c: 'info, 'info>(
         }
 
         (amount_0, amount_1) = swap_internal(
-            &ctx.amm_config,
+            ctx.amm_config,
             pool_state,
             tick_array_states,
             &mut ctx.observation_state.load_mut()?,
@@ -681,7 +687,7 @@ pub fn exact_internal<'b, 'c: 'info, 'info>(
         }
         // x -> y，transfer y token from pool vault to user.
         transfer_from_pool_vault_to_user(
-            &ctx.pool_state,
+            ctx.pool_state,
             &vault_1,
             &token_account_1,
             None,
@@ -704,7 +710,7 @@ pub fn exact_internal<'b, 'c: 'info, 'info>(
             ctx.pool_state.load_mut()?.set_status(255);
         }
         transfer_from_pool_vault_to_user(
-            &ctx.pool_state,
+            ctx.pool_state,
             &vault_0,
             &token_account_0,
             None,
@@ -744,12 +750,10 @@ pub fn exact_internal<'b, 'c: 'info, 'info>(
             } else {
                 require_eq!(amount_specified, amount_1);
             }
+        } else if zero_for_one {
+            require_eq!(amount_specified, amount_1);
         } else {
-            if zero_for_one {
-                require_eq!(amount_specified, amount_1);
-            } else {
-                require_eq!(amount_specified, amount_0);
-            }
+            require_eq!(amount_specified, amount_0);
         }
     }
 
@@ -823,6 +827,16 @@ pub fn swap_on_swap_state(
         return err!(ErrorCode::NotApproved);
     }
 
+    // Hot-path precomputations to avoid repeated work in the loop
+    let tick_spacing = pool_state.tick_spacing;
+    let has_protocol_fee = amm_config.protocol_fee_rate > 0;
+    let has_fund_fee = amm_config.fund_fee_rate > 0;
+    let denom_u128 = U128::from(FEE_RATE_DENOMINATOR_VALUE);
+    let q64_u128 = U128::from(fixed_point_64::Q64);
+    // Precompute fee rates as U128 to avoid converting every iteration
+    let protocol_rate_u128 = U128::from(amm_config.protocol_fee_rate);
+    let fund_rate_u128 = U128::from(amm_config.fund_fee_rate);
+
     let mut tick_array_current = tick_array_states
         .pop_front()
         .ok_or(ErrorCode::InvalidTickArrayBoundary)?;
@@ -830,7 +844,7 @@ pub fn swap_on_swap_state(
     // require_keys_eq!(tick_array_current.pool_id, pool_state.key());
 
     let (mut is_match_pool_current_tick_array, first_vaild_tick_array_start_index) =
-        pool_state.get_first_initialized_tick_array(&tickarray_bitmap_extension, zero_for_one)?;
+        pool_state.get_first_initialized_tick_array(tickarray_bitmap_extension, zero_for_one)?;
     let mut current_vaild_tick_array_start_index = first_vaild_tick_array_start_index;
 
     // Unecessary validation for quote estimation
@@ -864,6 +878,27 @@ pub fn swap_on_swap_state(
 
     // continue swapping as long as we haven't used the entire input/output and haven't
     // reached the price limit
+    // Reuse a default tick state to avoid re-initializing each loop
+    let default_tick_state = TickState::default();
+
+    // Build a 60-bit mask representing initialized ticks within the current array.
+    // This allows O(1) bit scans instead of O(60) linear scans per step.
+    #[inline(always)]
+    fn build_initialized_mask(tick_array: &TickArrayState) -> u64 {
+        let mut mask: u64 = 0;
+        let mut i: usize = 0;
+        while i < crate::states::tick_array::TICK_ARRAY_SIZE_USIZE {
+            if tick_array.ticks[i].is_initialized() {
+                mask |= 1u64 << i;
+            }
+            i += 1;
+        }
+        mask
+    }
+
+    let tick_spacing_i32: i32 = i32::from(tick_spacing);
+    let mut current_array_mask: u64 = build_initialized_mask(tick_array_current);
+
     while state.amount_specified_remaining != 0 && state.sqrt_price_x64 != sqrt_price_limit_x64 {
         #[cfg(feature = "enable-log")]
         msg!(
@@ -884,19 +919,67 @@ pub fn swap_on_swap_state(
         let mut step = StepComputations::default();
         step.sqrt_price_start_x64 = state.sqrt_price_x64;
 
-        let default_tick_state = TickState::default();
-        let mut next_initialized_tick = if let Some(tick_state) = tick_array_current
-            .next_initialized_tick(state.tick, pool_state.tick_spacing, zero_for_one)?
-        {
-            tick_state
-        } else {
-            if !is_match_pool_current_tick_array {
-                is_match_pool_current_tick_array = true;
-                tick_array_current.first_initialized_tick(zero_for_one)?
+        // Fast path: locate next initialized tick using bit scans within the current array.
+        let mut next_initialized_tick = {
+            let current_start = tick_array_current.start_tick_index;
+            if TickArrayState::get_array_start_index(state.tick, tick_spacing) != current_start {
+                None
             } else {
-                &default_tick_state
+                let mut offset_in_array = (state.tick - current_start) / tick_spacing_i32;
+                if zero_for_one {
+                    if offset_in_array < 0 {
+                        offset_in_array = 0;
+                    } else if offset_in_array >= crate::states::tick_array::TICK_ARRAY_SIZE {
+                        offset_in_array = crate::states::tick_array::TICK_ARRAY_SIZE - 1;
+                    }
+                    let upto = (offset_in_array as u32).saturating_add(1);
+                    let search_mask = if upto >= 64 {
+                        current_array_mask
+                    } else {
+                        current_array_mask & ((1u64 << upto) - 1)
+                    };
+                    if search_mask != 0 {
+                        let idx = 63u32.saturating_sub(search_mask.leading_zeros());
+                        Some(&tick_array_current.ticks[idx as usize])
+                    } else {
+                        None
+                    }
+                } else {
+                    let mut start_bit = offset_in_array + 1;
+                    if start_bit < 0 {
+                        start_bit = 0;
+                    } else if start_bit > crate::states::tick_array::TICK_ARRAY_SIZE {
+                        start_bit = crate::states::tick_array::TICK_ARRAY_SIZE;
+                    }
+                    let search_mask = if start_bit >= 64 {
+                        0u64
+                    } else if start_bit <= 0 {
+                        current_array_mask
+                    } else {
+                        current_array_mask & (!((1u64 << (start_bit as u32)) - 1))
+                    };
+                    if search_mask != 0 {
+                        let idx = search_mask.trailing_zeros();
+                        Some(&tick_array_current.ticks[idx as usize])
+                    } else {
+                        None
+                    }
+                }
             }
         };
+        if next_initialized_tick.is_none() {
+            next_initialized_tick = if let Some(tick_state) =
+                tick_array_current.next_initialized_tick(state.tick, tick_spacing, zero_for_one)?
+            {
+                Some(tick_state)
+            } else if !is_match_pool_current_tick_array {
+                is_match_pool_current_tick_array = true;
+                Some(tick_array_current.first_initialized_tick(zero_for_one)?)
+            } else {
+                None
+            };
+        }
+        let mut next_initialized_tick = next_initialized_tick.unwrap_or(&default_tick_state);
         #[cfg(feature = "enable-log")]
         msg!(
             "next_initialized_tick, status:{}, tick_index:{}, tick_array_current:{}",
@@ -907,7 +990,7 @@ pub fn swap_on_swap_state(
         if !next_initialized_tick.is_initialized() {
             let next_initialized_tickarray_index = pool_state
                 .next_initialized_tick_array_start_index(
-                    &tickarray_bitmap_extension,
+                    tickarray_bitmap_extension,
                     current_vaild_tick_array_start_index,
                     zero_for_one,
                 )?;
@@ -917,6 +1000,8 @@ pub fn swap_on_swap_state(
             tick_array_current = tick_array_states
                 .pop_front()
                 .ok_or(ErrorCode::InvalidTickArrayBoundary)?;
+            // Recompute the mask for the new array
+            current_array_mask = build_initialized_mask(tick_array_current);
 
             // let expected_next_tick_array_address = Pubkey::find_program_address(
             //     &[
@@ -1016,46 +1101,56 @@ pub fn swap_on_swap_state(
                 .ok_or(ErrorCode::CalculateOverflow)?;
         }
 
-        let step_fee_amount = step.fee_amount;
-        // if the protocol fee is on, calculate how much is owed, decrement fee_amount, and increment protocol_fee
-        if amm_config.protocol_fee_rate > 0 {
-            let delta = U128::from(step_fee_amount)
-                .checked_mul(amm_config.protocol_fee_rate.into())
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .checked_div(FEE_RATE_DENOMINATOR_VALUE.into())
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .as_u64();
-            step.fee_amount = step
-                .fee_amount
-                .checked_sub(delta)
-                .ok_or(ErrorCode::CalculateOverflow)?;
-            state.protocol_fee = state
-                .protocol_fee
-                .checked_add(delta)
-                .ok_or(ErrorCode::CalculateOverflow)?;
-        }
-        // if the fund fee is on, calculate how much is owed, decrement fee_amount, and increment fund_fee
-        if amm_config.fund_fee_rate > 0 {
-            let delta = U128::from(step_fee_amount)
-                .checked_mul(amm_config.fund_fee_rate.into())
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .checked_div(FEE_RATE_DENOMINATOR_VALUE.into())
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .as_u64();
-            step.fee_amount = step
-                .fee_amount
-                .checked_sub(delta)
-                .ok_or(ErrorCode::CalculateOverflow)?;
-            state.fund_fee = state
-                .fund_fee
-                .checked_add(delta)
-                .ok_or(ErrorCode::CalculateOverflow)?;
+        // if the protocol/fund fee is on, calculate how much is owed, decrement fee_amount, and increment fee trackers
+        // Compute both deltas against the same base (step_fee_amount) to preserve rounding and behavior
+        if has_protocol_fee || has_fund_fee {
+            let fee_base_u128 = U128::from(step.fee_amount);
+            let mut total_fee_delta: u64 = 0;
+
+            if has_protocol_fee {
+                let delta = fee_base_u128
+                    .checked_mul(protocol_rate_u128)
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .checked_div(denom_u128)
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .as_u64();
+                state.protocol_fee = state
+                    .protocol_fee
+                    .checked_add(delta)
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+                total_fee_delta = total_fee_delta
+                    .checked_add(delta)
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+            }
+
+            if has_fund_fee {
+                let delta = fee_base_u128
+                    .checked_mul(fund_rate_u128)
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .checked_div(denom_u128)
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .as_u64();
+                state.fund_fee = state
+                    .fund_fee
+                    .checked_add(delta)
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+                total_fee_delta = total_fee_delta
+                    .checked_add(delta)
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+            }
+
+            if total_fee_delta != 0 {
+                step.fee_amount = step
+                    .fee_amount
+                    .checked_sub(total_fee_delta)
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+            }
         }
 
         // update global fee tracker
         if state.liquidity > 0 {
             let fee_growth_global_x64_delta = U128::from(step.fee_amount)
-                .mul_div_floor(U128::from(fixed_point_64::Q64), U128::from(state.liquidity))
+                .mul_div_floor(q64_u128, U128::from(state.liquidity))
                 .ok_or(ErrorCode::CalculateOverflow)?
                 .as_u128();
 
@@ -1284,7 +1379,8 @@ mod swap_test {
                     tick_math::get_sqrt_price_at_tick(position_param.tick_upper).unwrap(),
                     position_param.amount_0,
                     position_param.amount_1,
-                );
+                )
+                .unwrap();
 
                 let (amount_0, amount_1) = get_delta_amounts_signed(
                     start_tick,
@@ -2683,6 +2779,7 @@ mod swap_test {
     mod sqrt_price_limit_optimization_test {
         use super::*;
         use proptest::prelude::*;
+        use rand::Rng;
         use std::{convert::identity, u64};
 
         use proptest::prop_assume;

--- a/programs/amm/src/libraries/liquidity_math.rs
+++ b/programs/amm/src/libraries/liquidity_math.rs
@@ -195,7 +195,7 @@ pub fn get_delta_amount_0_unsigned(
     if result > U256::from(u64::MAX) {
         return Err(ErrorCode::MaxTokenOverflow.into());
     }
-    return Ok(result.as_u64());
+    Ok(result.as_u64())
 }
 
 /// Gets the delta amount_1 for given liquidity and price range
@@ -226,7 +226,7 @@ pub fn get_delta_amount_1_unsigned(
     if result > U256::from(u64::MAX) {
         return Err(ErrorCode::MaxTokenOverflow.into());
     }
-    return Ok(result.as_u64());
+    Ok(result.as_u64())
 }
 
 /// Helper function to get signed delta amount_0 for given liquidity and price range

--- a/programs/amm/src/libraries/sqrt_price_math.rs
+++ b/programs/amm/src/libraries/sqrt_price_math.rs
@@ -27,6 +27,7 @@ use super::{fixed_point_64, U256};
 /// √P' = √P * L / L'
 /// √P' = √P * L / (L + Δx*√P)
 ///
+#[inline(always)]
 pub fn get_next_sqrt_price_from_amount_0_rounding_up(
     sqrt_price_x64: u128,
     liquidity: u128,
@@ -40,7 +41,7 @@ pub fn get_next_sqrt_price_from_amount_0_rounding_up(
 
     if add {
         if let Some(product) = U256::from(amount).checked_mul(U256::from(sqrt_price_x64)) {
-            let denominator = numerator_1 + U256::from(product);
+            let denominator = numerator_1 + product;
             if denominator >= numerator_1 {
                 return numerator_1
                     .mul_div_ceil(U256::from(sqrt_price_x64), denominator)
@@ -57,11 +58,9 @@ pub fn get_next_sqrt_price_from_amount_0_rounding_up(
         )
         .as_u128()
     } else {
-        let product = U256::from(
-            U256::from(amount)
+        let product = U256::from(amount)
                 .checked_mul(U256::from(sqrt_price_x64))
-                .unwrap(),
-        );
+                .unwrap();
         let denominator = numerator_1.checked_sub(product).unwrap();
         numerator_1
             .mul_div_ceil(U256::from(sqrt_price_x64), denominator)
@@ -84,6 +83,7 @@ pub fn get_next_sqrt_price_from_amount_0_rounding_up(
 ///
 /// * `√P' = √P + Δy / L`
 ///
+#[inline(always)]
 pub fn get_next_sqrt_price_from_amount_1_rounding_down(
     sqrt_price_x64: u128,
     liquidity: u128,
@@ -104,6 +104,7 @@ pub fn get_next_sqrt_price_from_amount_1_rounding_down(
 
 /// Gets the next sqrt price given an input amount of token_0 or token_1
 /// Throws if price or liquidity are 0, or if the next price is out of bounds
+#[inline(always)]
 pub fn get_next_sqrt_price_from_input(
     sqrt_price_x64: u128,
     liquidity: u128,
@@ -125,6 +126,7 @@ pub fn get_next_sqrt_price_from_input(
 ///
 /// Throws if price or liquidity are 0 or the next price is out of bounds
 ///
+#[inline(always)]
 pub fn get_next_sqrt_price_from_output(
     sqrt_price_x64: u128,
     liquidity: u128,

--- a/programs/amm/src/libraries/swap_math.rs
+++ b/programs/amm/src/libraries/swap_math.rs
@@ -15,6 +15,7 @@ pub struct SwapStep {
 }
 
 /// Computes the result of swapping some amount in, or amount out, given the parameters of the swap
+#[inline(always)]
 pub fn compute_swap_step(
     sqrt_price_current_x64: u128,
     sqrt_price_target_x64: u128,
@@ -27,14 +28,17 @@ pub fn compute_swap_step(
 ) -> Result<SwapStep> {
     // let exact_in = amount_remaining >= 0;
     let mut swap_step = SwapStep::default();
+    // Precompute fee denominators as u64 to avoid repeated conversions
+    let fee_denom_u64: u64 = u64::from(FEE_RATE_DENOMINATOR_VALUE);
+    let fee_denom_minus_fee_u64: u64 = fee_denom_u64
+        .checked_sub(u64::from(fee_rate))
+        .ok_or(ErrorCode::CalculateOverflow)?;
+
     if is_base_input {
         // round up amount_in
         // In exact input case, amount_remaining is positive
-        let amount_remaining_less_fee = (amount_remaining as u64)
-            .mul_div_floor(
-                (FEE_RATE_DENOMINATOR_VALUE - fee_rate).into(),
-                u64::from(FEE_RATE_DENOMINATOR_VALUE),
-            )
+        let amount_remaining_less_fee = amount_remaining
+            .mul_div_floor(fee_denom_minus_fee_u64, fee_denom_u64)
             .ok_or(ErrorCode::CalculateOverflow)?;
 
         let amount_in = calculate_amount_in_range(
@@ -136,17 +140,14 @@ pub fn compute_swap_step(
         if is_base_input && swap_step.sqrt_price_next_x64 != sqrt_price_target_x64 {
             // we didn't reach the target, so take the remainder of the maximum input as fee
             // swap dust is granted as fee
-            u64::from(amount_remaining)
+            amount_remaining
                 .checked_sub(swap_step.amount_in)
                 .ok_or(ErrorCode::CalculateOverflow)?
         } else {
             // take pip percentage as fee
             swap_step
                 .amount_in
-                .mul_div_ceil(
-                    fee_rate.into(),
-                    (FEE_RATE_DENOMINATOR_VALUE - fee_rate).into(),
-                )
+                .mul_div_ceil(fee_rate.into(), fee_denom_minus_fee_u64)
                 .ok_or(ErrorCode::CalculateOverflow)?
         };
 
@@ -183,13 +184,11 @@ fn calculate_amount_in_range(
         };
 
         if result.is_ok() {
-            return Ok(Some(result.unwrap()));
+            Ok(Some(result.unwrap()))
+        } else if result.err().unwrap() == crate::error::ErrorCode::MaxTokenOverflow.into() {
+            Ok(None)
         } else {
-            if result.err().unwrap() == crate::error::ErrorCode::MaxTokenOverflow.into() {
-                return Ok(None);
-            } else {
-                return Err(ErrorCode::SqrtPriceLimitOverflow.into());
-            }
+            Err(ErrorCode::SqrtPriceLimitOverflow.into())
         }
     } else {
         let result = if zero_for_one {
@@ -208,13 +207,11 @@ fn calculate_amount_in_range(
             )
         };
         if result.is_ok() {
-            return Ok(Some(result.unwrap()));
+            Ok(Some(result.unwrap()))
+        } else if result.err().unwrap() == crate::error::ErrorCode::MaxTokenOverflow.into() {
+            Ok(None)
         } else {
-            if result.err().unwrap() == crate::error::ErrorCode::MaxTokenOverflow.into() {
-                return Ok(None);
-            } else {
-                return Err(ErrorCode::SqrtPriceLimitOverflow.into());
-            }
+            Err(ErrorCode::SqrtPriceLimitOverflow.into())
         }
     }
 }

--- a/programs/amm/src/libraries/tick_array_bit_map.rs
+++ b/programs/amm/src/libraries/tick_array_bit_map.rs
@@ -67,7 +67,7 @@ pub fn check_current_tick_array_is_initialized(
         return Ok((true, (compressed - 512) * multiplier));
     }
     // the current bit is not initialized
-    return Ok((false, (compressed - 512) * multiplier));
+    Ok((false, (compressed - 512) * multiplier))
 }
 
 pub fn next_initialized_tick_array_start_index(

--- a/programs/amm/src/libraries/tick_math.rs
+++ b/programs/amm/src/libraries/tick_math.rs
@@ -29,7 +29,7 @@ const BIT_PRECISION: u32 = 16;
 /// * `tick` - Price tick
 ///
 pub fn get_sqrt_price_at_tick(tick: i32) -> Result<u128, anchor_lang::error::Error> {
-    let abs_tick = tick.abs() as u32;
+    let abs_tick = tick.unsigned_abs();
     require!(abs_tick <= MAX_TICK as u32, ErrorCode::TickUpperOverflow);
 
     // i = 0
@@ -127,7 +127,7 @@ pub fn get_sqrt_price_at_tick(tick: i32) -> Result<u128, anchor_lang::error::Err
 pub fn get_tick_at_sqrt_price(sqrt_price_x64: u128) -> Result<i32, anchor_lang::error::Error> {
     // second inequality must be < because the price can never reach the price at the max tick
     require!(
-        sqrt_price_x64 >= MIN_SQRT_PRICE_X64 && sqrt_price_x64 < MAX_SQRT_PRICE_X64,
+        (MIN_SQRT_PRICE_X64..MAX_SQRT_PRICE_X64).contains(&sqrt_price_x64),
         ErrorCode::SqrtPriceX64
     );
 
@@ -152,7 +152,7 @@ pub fn get_tick_at_sqrt_price(sqrt_price_x64: u128) -> Result<i32, anchor_lang::
 
     while bit > 0 && precision < BIT_PRECISION {
         r *= r;
-        let is_r_more_than_two = r >> 127 as u32;
+        let is_r_more_than_two = r >> 127_u32;
         r >>= 63 + is_r_more_than_two;
         log2p_fraction_x64 += bit * is_r_more_than_two as i128;
         bit >>= 1;

--- a/programs/amm/src/libraries/unsafe_math.rs
+++ b/programs/amm/src/libraries/unsafe_math.rs
@@ -11,7 +11,7 @@ pub trait UnsafeMathTrait {
 
 impl UnsafeMathTrait for u64 {
     fn div_rounding_up(x: Self, y: Self) -> Self {
-        x / y + ((x % y > 0) as u64)
+        x / y + (!x.is_multiple_of(y) as u64)
     }
 }
 

--- a/programs/amm/src/states/tick_array.rs
+++ b/programs/amm/src/states/tick_array.rs
@@ -143,7 +143,8 @@ impl TickArrayState {
     }
 
     /// Get tick's offset in current tick array, tick must be include in tick array， otherwise throw an error
-    fn get_tick_offset_in_array(self, tick_index: i32, tick_spacing: u16) -> Result<usize> {
+    #[inline(always)]
+    fn get_tick_offset_in_array(&self, tick_index: i32, tick_spacing: u16) -> Result<usize> {
         let start_tick_index = TickArrayState::get_array_start_index(tick_index, tick_spacing);
         require_eq!(
             start_tick_index,
@@ -156,6 +157,7 @@ impl TickArrayState {
     }
 
     /// Base on swap directioin, return the first initialized tick in the tick array.
+    #[inline(always)]
     pub fn first_initialized_tick(&self, zero_for_one: bool) -> Result<&TickState> {
         if zero_for_one {
             let mut i = TICK_ARRAY_SIZE - 1;
@@ -163,7 +165,7 @@ impl TickArrayState {
                 if self.ticks[i as usize].is_initialized() {
                     return Ok(self.ticks.get(i as usize).unwrap());
                 }
-                i = i - 1;
+                i -= 1;
             }
         } else {
             let mut i = 0;
@@ -171,7 +173,7 @@ impl TickArrayState {
                 if self.ticks[i].is_initialized() {
                     return Ok(self.ticks.get(i).unwrap());
                 }
-                i = i + 1;
+                i += 1;
             }
         }
         err!(ErrorCode::InvalidTickArray)
@@ -180,6 +182,7 @@ impl TickArrayState {
     /// Get next initialized tick in tick array, `current_tick_index` can be any tick index, in other words, `current_tick_index` not exactly a point in the tickarray,
     /// and current_tick_index % tick_spacing maybe not equal zero.
     /// If price move to left tick <= current_tick_index, or to right tick > current_tick_index
+    #[inline(always)]
     pub fn next_initialized_tick(
         &self,
         current_tick_index: i32,
@@ -199,15 +202,15 @@ impl TickArrayState {
                 if self.ticks[offset_in_array as usize].is_initialized() {
                     return Ok(self.ticks.get(offset_in_array as usize));
                 }
-                offset_in_array = offset_in_array - 1;
+                offset_in_array -= 1;
             }
         } else {
-            offset_in_array = offset_in_array + 1;
+            offset_in_array += 1;
             while offset_in_array < TICK_ARRAY_SIZE {
                 if self.ticks[offset_in_array as usize].is_initialized() {
                     return Ok(self.ticks.get(offset_in_array as usize));
                 }
-                offset_in_array = offset_in_array + 1;
+                offset_in_array += 1;
             }
         }
         Ok(None)
@@ -228,7 +231,7 @@ impl TickArrayState {
         let ticks_in_array = TickArrayState::tick_count(tick_spacing);
         let mut start = tick_index / ticks_in_array;
         if tick_index < 0 && tick_index % ticks_in_array != 0 {
-            start = start - 1
+            start -= 1
         }
         start * ticks_in_array
     }
@@ -375,14 +378,15 @@ impl TickState {
         self.reward_growths_outside_x64 = [0; REWARD_NUM];
     }
 
-    pub fn is_initialized(self) -> bool {
+    #[inline(always)]
+    pub fn is_initialized(&self) -> bool {
         self.liquidity_gross != 0
     }
 
     /// Common checks for a valid tick input.
     /// A tick is valid if it lies within tick boundaries
     pub fn check_is_out_of_boundary(tick: i32) -> bool {
-        tick < tick_math::MIN_TICK || tick > tick_math::MAX_TICK
+        !(tick_math::MIN_TICK..=tick_math::MAX_TICK).contains(&tick)
     }
 }
 

--- a/programs/amm/src/states/tickarray_bitmap_extension.rs
+++ b/programs/amm/src/states/tickarray_bitmap_extension.rs
@@ -117,9 +117,9 @@ impl TickArrayBitmapExtension {
         let tick_array_bitmap = U512(tick_array_bitmap);
         let mask = U512::one() << tick_array_offset_in_bitmap;
         if tick_array_start_index < 0 {
-            self.negative_tick_array_bitmap[offset as usize] = tick_array_bitmap.bitxor(mask).0;
+            self.negative_tick_array_bitmap[offset] = tick_array_bitmap.bitxor(mask).0;
         } else {
-            self.positive_tick_array_bitmap[offset as usize] = tick_array_bitmap.bitxor(mask).0;
+            self.positive_tick_array_bitmap[offset] = tick_array_bitmap.bitxor(mask).0;
         }
         Ok(())
     }
@@ -185,10 +185,10 @@ impl TickArrayBitmapExtension {
             if next_bit.is_some() {
                 let next_array_start_index = next_tick_array_start_index
                     - i32::from(next_bit.unwrap()) * TickArrayState::tick_count(tick_spacing);
-                return (true, next_array_start_index);
+                (true, next_array_start_index)
             } else {
                 // not found til to the end
-                return (false, bitmap_min_tick_boundary);
+                (false, bitmap_min_tick_boundary)
             }
         } else {
             // tick from lower to upper
@@ -203,13 +203,13 @@ impl TickArrayBitmapExtension {
             if next_bit.is_some() {
                 let next_array_start_index = next_tick_array_start_index
                     + i32::from(next_bit.unwrap()) * TickArrayState::tick_count(tick_spacing);
-                return (true, next_array_start_index);
+                (true, next_array_start_index)
             } else {
                 // not found til to the end
-                return (
+                (
                     false,
                     bitmap_max_tick_boundary - TickArrayState::tick_count(tick_spacing),
-                );
+                )
             }
         }
     }


### PR DESCRIPTION
- swap_on_swap_state:
  - Use 60-bit initialized-tick mask + bit scans for O(1) next-tick lookup
  - Cache tick->sqrt conversion per iteration
  - Minor control-flow tightening; borrow/iter cleanups; fewer conversions
- swap_math: inline compute_swap_step and precompute fee denominators
- sqrt_price_math: inline hot sqrt-price helpers
- tick_array:
  - Inline first/next initialized tick helpers
  - Avoid by-value receivers; use &self
  - Use compound ops (+=, -=) and range contains for bounds
- Preserve exact behavior and rounding; no protocol changes