### PR TITLE
fix: port upstream limit-order / dynamic-fee quoting fixes

### DIFF
--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -699,7 +699,10 @@ pub fn swap_internal<'b, 'c: 'info, 'info>(
                     is_fee_on_input,
                 )?;
 
-                if limit_order_result.amount_in > 0 {
+                if limit_order_result.amount_in != 0
+                    || limit_order_result.amount_out != 0
+                    || limit_order_result.amm_fee_amount != 0
+                {
                     #[cfg(feature = "enable-log")]
                     msg!(
                         "limit_order_result: amount_in:{}, amount_out:{}, amm_fee_amount:{}",
@@ -1325,7 +1328,10 @@ pub fn swap_on_swap_state_with_cache(
                     is_fee_on_input,
                 )?;
 
-                if limit_order_result.amount_in > 0 {
+                if limit_order_result.amount_in != 0
+                    || limit_order_result.amount_out != 0
+                    || limit_order_result.amm_fee_amount != 0
+                {
                     state.apply_swap_amounts(
                         limit_order_result.amount_in,
                         limit_order_result.amount_out,

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -781,6 +781,7 @@ pub fn swap_internal<'b, 'c: 'info, 'info>(
                     tick_math::get_tick_at_sqrt_price(swap_computed_result.sqrt_price_next_x64)?;
             }
             state.sqrt_price_x64 = swap_computed_result.sqrt_price_next_x64;
+            state.update_dynamic_fee_index(zero_for_one, is_skipped_tick_spacing)?;
             if state.amount_specified_remaining == 0 || state.sqrt_price_x64 == target_price {
                 let limit_order_unfilled_amount_after =
                     next_initialized_tick.limit_order_unfilled_amount()?;
@@ -793,7 +794,6 @@ pub fn swap_internal<'b, 'c: 'info, 'info>(
                 }
                 break;
             }
-            state.update_dynamic_fee_index(zero_for_one, is_skipped_tick_spacing)?;
         }
         state.liquidity = liquidity_next;
     }
@@ -1369,6 +1369,7 @@ pub fn swap_on_swap_state_with_cache(
                     tick_math::get_tick_at_sqrt_price(swap_computed_result.sqrt_price_next_x64)?;
             }
             state.sqrt_price_x64 = swap_computed_result.sqrt_price_next_x64;
+            state.update_dynamic_fee_index(zero_for_one, is_skipped_tick_spacing)?;
             if state.amount_specified_remaining == 0 || state.sqrt_price_x64 == target_price {
                 let limit_order_unfilled_amount_after =
                     next_initialized_tick.limit_order_unfilled_amount()?;
@@ -1379,7 +1380,6 @@ pub fn swap_on_swap_state_with_cache(
                 }
                 break;
             }
-            state.update_dynamic_fee_index(zero_for_one, is_skipped_tick_spacing)?;
         }
         state.liquidity = liquidity_next;
     }

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -401,19 +401,6 @@ impl SwapState {
         Ok(())
     }
 
-    pub fn update_volatility_accumulator_on_price(&mut self) -> Result<()> {
-        if self.dynamic_fee_info.is_some() {
-            let tick_index = tick_math::get_tick_at_sqrt_price(self.sqrt_price_x64)?;
-            let final_tick_spacing_index =
-                tick_spacing_index_from_tick(tick_index, self.tick_spacing)?;
-            if self.tick_spacing_index != final_tick_spacing_index {
-                self.tick_spacing_index = final_tick_spacing_index;
-                self.update_volatility_accumulator()?;
-            }
-        }
-        Ok(())
-    }
-
     pub fn get_spacing_bounded_price(
         &self,
         target_price: u128,
@@ -800,9 +787,6 @@ pub fn swap_internal<'b, 'c: 'info, 'info>(
         }
         state.liquidity = liquidity_next;
     }
-    // At the end of the entire swap loop, `updating_dynamic_fee_index` does not always guarantee that the tick_spacing_index lands in the correct position.
-    // Therefore, we recalculate its position here based on the current price and update the volatility accumulator.
-    state.update_volatility_accumulator_on_price()?;
 
     #[cfg(feature = "enable-log")]
     msg!("end, state:{:#?}", state);
@@ -1389,7 +1373,6 @@ pub fn swap_on_swap_state_with_cache(
         }
         state.liquidity = liquidity_next;
     }
-    state.update_volatility_accumulator_on_price()?;
 
     // Quote-path: skip `observation_state.update(...)` and `pool_state.update_after_swap(...)`.
 

--- a/programs/amm/src/libraries/swap_math.rs
+++ b/programs/amm/src/libraries/swap_math.rs
@@ -190,6 +190,15 @@ pub fn compute_swap(
                 .amount_out
                 .checked_sub(result.fee_amount)
                 .ok_or(ErrorCode::CalculateOverflow)?;
+
+            // Partial step: the price moved less than the exact input warrants (rounded toward the
+            // pool — down for one_for_zero, up for zero_for_one), so amount_in recomputed from that
+            // move can be below the available input, leaving an un-tradeable dust (< liquidity/Q64).
+            // Fee-on-input folds it into the fee, fee-on-output cannot, so it would stall the loop.
+            // Charge the full input (== amount_remaining here); the sub-unit excess goes to the pool.
+            if !max {
+                result.amount_in = amount_remaining;
+            }
         }
     } else {
         if is_fee_on_input {

--- a/programs/amm/src/states/pool.rs
+++ b/programs/amm/src/states/pool.rs
@@ -433,6 +433,14 @@ impl PoolState {
             if is_found {
                 return Ok(Some(start_index));
             }
+            // When tick_spacing >= 15 the default bitmap already spans the entire
+            // [MIN_TICK, MAX_TICK] range (tick_spacing * 60 * 512 >= MAX_TICK), so a miss means the
+            // direction is exhausted and no extension bitmap exists to search. Return None so the
+            // caller surfaces LiquidityInsufficient, instead of demanding a non-existent extension
+            // account (which would misreport MissingTickArrayBitmapExtensionAccount).
+            if self.tick_spacing >= 15 {
+                return Ok(None);
+            }
             last_tick_array_start_index = start_index;
 
             // Only load extension when needed (after default bitmap search fails)
@@ -513,6 +521,14 @@ impl PoolState {
                 )?;
             if is_found {
                 return Ok(Some(start_index));
+            }
+            // When tick_spacing >= 15 the default bitmap already spans the entire
+            // [MIN_TICK, MAX_TICK] range (tick_spacing * 60 * 512 >= MAX_TICK), so a miss means the
+            // direction is exhausted and no extension bitmap exists to search. Return None so the
+            // caller surfaces LiquidityInsufficient, instead of demanding a non-existent extension
+            // account (which would misreport MissingTickArrayBitmapExtensionAccount).
+            if self.tick_spacing >= 15 {
+                return Ok(None);
             }
             last_tick_array_start_index = start_index;
 


### PR DESCRIPTION
bring sdk up to date with the upstream raydium-io/raydium-clmm fixes 
Each upstream commit was reviewed individually

## Commits
| Upstream | What / why |
|---|---|
| `cf5db98` (`fc4c866`) | Advance the dynamic-fee tick-spacing index *before* the swap-loop break. Skipping it under-counted volatility on multi-tick swaps → under-charged dynamic fee → **over-quote**. Only affects dynamic-fee pools. |
| `6dcdd56` (`474d774`) | Apply a limit-order match result when it yields fee/output even with `amount_in == 0`, consuming the dust instead of carrying it forward (closes a narrow dust over-quote path). |
| `f3b4ef7` (`de297d2`) | Drop the dead `update_volatility_accumulator_on_price` (swap.rs portion only). Quote-neutral: it ran after the loop and only touched the persisted dynamic-fee state, which `settle_amounts` never reads. The `MAX_TICK_SPACING` admin cap in that commit has no surface in this quoting-only fork. |
| `fcad161` (`7f88ead`) | (a) A partial fee-on-output exact-input step now charges the full input (sub-unit dust → pool) so the swap **fills**, matching on-chain, instead of being rejected by our no-progress guard on `fee_on=1/2` pools. (b) Short-circuit the tick-array lookup to `Ok(None)` when `tick_spacing >= 15`, surfacing `LiquidityInsufficient` instead of a misleading `MissingTickArrayBitmapExtensionAccount`. |

`5e13240` (limit-order placement check) was reviewed and **skipped** — it touches `open_limit_order` / `increase_limit_order`, which don't exist in this quoting-only fork.

## Deliberate divergences from upstream
- **Kept** the fork's `compute_swap` no-progress guard (`225535e`) alongside the `fcad161` dust-consume. Upstream relies on the on-chain CU limit to stop a runaway loop; this off-chain quoter has no such ceiling, so the guard stays as cheap hang-insurance against malformed account data. With the dust now consumed, it no longer fires in normal operation.
- Existing safer narrowing (`try_into → CalculateOverflow` vs upstream's `.as_u64()`) is retained.

## Net effect
- Fixes the one genuine **over-quote** path (`cf5db98`, multi-tick dynamic-fee pools).
- Eliminates **false `LiquidityInsufficient` rejections** on the new `fee_on=1/2` limit-order pools — the quoter now fills the same exact-input dust-tail swaps the live program fills.
- Both swap loops kept in sync.

## Testing
- `cargo build` clean.
- `cargo test -p raydium-amm-v3 --lib`: 55 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)