### PR TITLE
optimize limit order quote math

### DIFF
--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -678,12 +678,13 @@ pub fn swap_internal<'b, 'c: 'info, 'info>(
                 next_initialized_tick.limit_order_unfilled_amount()?;
             if state.sqrt_price_next_x64 == swap_computed_result.sqrt_price_next_x64 {
                 // try to match limit orders on this tick
-                let limit_order_result = next_initialized_tick.match_limit_order(
+                let limit_order_result = next_initialized_tick.match_limit_order_with_sqrt_price(
                     state.amount_specified_remaining,
                     zero_for_one,
                     is_base_input,
                     total_fee_rate,
                     is_fee_on_input,
+                    state.sqrt_price_next_x64,
                 )?;
 
                 if limit_order_result.amount_in != 0
@@ -1304,12 +1305,13 @@ pub fn swap_on_swap_state_with_cache(
             let limit_order_unfilled_amount_before =
                 next_initialized_tick.limit_order_unfilled_amount()?;
             if state.sqrt_price_next_x64 == swap_computed_result.sqrt_price_next_x64 {
-                let limit_order_result = next_initialized_tick.match_limit_order(
+                let limit_order_result = next_initialized_tick.match_limit_order_with_sqrt_price(
                     state.amount_specified_remaining,
                     zero_for_one,
                     is_base_input,
                     total_fee_rate,
                     is_fee_on_input,
+                    state.sqrt_price_next_x64,
                 )?;
 
                 if limit_order_result.amount_in != 0

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -1162,11 +1162,11 @@ struct CachedInitializedTick {
 
 #[derive(Clone, Copy)]
 struct CachedTickQuote {
-    tick: i32,
     sqrt_price_x64: u128,
     price_x64_down: U128,
     price_x64_up: U128,
     total_unfilled_amount: u64,
+    swap_step_amounts: Option<swap_math::SwapStepAmountCache>,
 }
 
 impl CachedTickQuote {
@@ -1182,14 +1182,22 @@ impl CachedTickQuote {
 
 impl TickArrayQuoteCache {
     pub fn from_tick_array(tick_array: &TickArrayState) -> Result<Self> {
+        let pool_id = unsafe { core::ptr::addr_of!((*tick_array).pool_id).read_unaligned() };
+        let start_tick_index =
+            unsafe { core::ptr::addr_of!((*tick_array).start_tick_index).read_unaligned() };
+        let recent_epoch =
+            unsafe { core::ptr::addr_of!((*tick_array).recent_epoch).read_unaligned() };
+        let initialized_tick_count =
+            unsafe { core::ptr::addr_of!((*tick_array).initialized_tick_count).read_unaligned() };
         let mut cache = Self {
-            pool_id: tick_array.pool_id,
-            start_tick_index: tick_array.start_tick_index,
-            recent_epoch: tick_array.recent_epoch,
-            initialized_ticks: Vec::with_capacity(tick_array.initialized_tick_count as usize),
+            pool_id,
+            start_tick_index,
+            recent_epoch,
+            initialized_ticks: Vec::with_capacity(initialized_tick_count as usize),
         };
 
-        for (tick_offset, tick) in tick_array.ticks.iter().enumerate() {
+        for tick_offset in 0..TICK_ARRAY_SIZE_USIZE {
+            let tick = read_tick_unaligned(tick_array, tick_offset);
             if !tick.is_initialized() {
                 continue;
             }
@@ -1199,7 +1207,6 @@ impl TickArrayQuoteCache {
                 tick_index,
                 tick_offset,
                 quote: CachedTickQuote {
-                    tick: tick.tick,
                     sqrt_price_x64,
                     price_x64_down: tick_math::get_price_from_sqrt_price_x64(
                         sqrt_price_x64,
@@ -1207,17 +1214,113 @@ impl TickArrayQuoteCache {
                     )?,
                     price_x64_up: tick_math::get_price_from_sqrt_price_x64(sqrt_price_x64, true)?,
                     total_unfilled_amount: tick.limit_order_unfilled_amount()?,
+                    swap_step_amounts: None,
                 },
             });
         }
         Ok(cache)
     }
 
+    pub fn from_tick_arrays_for_swap(
+        pool_state: &PoolState,
+        tick_arrays: VecDeque<&TickArrayState>,
+        zero_for_one: bool,
+    ) -> Result<Vec<Self>> {
+        let mut caches = Vec::with_capacity(tick_arrays.len());
+        let mut sqrt_price_current_x64 =
+            unsafe { core::ptr::addr_of!((*pool_state).sqrt_price_x64).read_unaligned() };
+        let mut liquidity =
+            unsafe { core::ptr::addr_of!((*pool_state).liquidity).read_unaligned() };
+        let mut current_tick_index =
+            unsafe { core::ptr::addr_of!((*pool_state).tick_current).read_unaligned() };
+
+        for tick_array in tick_arrays {
+            let mut cache = Self::from_tick_array(tick_array)?;
+            if zero_for_one {
+                for index in (0..cache.initialized_ticks.len()).rev() {
+                    cache.populate_swap_step_amounts(
+                        tick_array,
+                        index,
+                        zero_for_one,
+                        &mut sqrt_price_current_x64,
+                        &mut liquidity,
+                        &mut current_tick_index,
+                    )?;
+                }
+            } else {
+                for index in 0..cache.initialized_ticks.len() {
+                    cache.populate_swap_step_amounts(
+                        tick_array,
+                        index,
+                        zero_for_one,
+                        &mut sqrt_price_current_x64,
+                        &mut liquidity,
+                        &mut current_tick_index,
+                    )?;
+                }
+            }
+            caches.push(cache);
+        }
+
+        Ok(caches)
+    }
+
+    fn populate_swap_step_amounts(
+        &mut self,
+        tick_array: &TickArrayState,
+        index: usize,
+        zero_for_one: bool,
+        sqrt_price_current_x64: &mut u128,
+        liquidity: &mut u128,
+        current_tick_index: &mut i32,
+    ) -> Result<()> {
+        let tick_index = self.initialized_ticks[index].tick_index;
+        let is_reachable = if zero_for_one {
+            tick_index <= *current_tick_index
+        } else {
+            tick_index > *current_tick_index
+        };
+        if !is_reachable {
+            return Ok(());
+        }
+
+        let tick_state = read_tick_unaligned(tick_array, self.initialized_ticks[index].tick_offset);
+        let sqrt_price_target_x64 = self.initialized_ticks[index].quote.sqrt_price_x64;
+        self.initialized_ticks[index].quote.swap_step_amounts =
+            Some(swap_math::cached_swap_step_amounts(
+                *sqrt_price_current_x64,
+                sqrt_price_target_x64,
+                *liquidity,
+                zero_for_one,
+            )?);
+        *sqrt_price_current_x64 = sqrt_price_target_x64;
+
+        if tick_state.has_liquidity() && !tick_state.has_limit_orders() {
+            let mut liquidity_net = tick_state.liquidity_net;
+            if zero_for_one {
+                liquidity_net = liquidity_net.neg();
+            }
+            *liquidity = liquidity_math::add_delta(*liquidity, liquidity_net)?;
+        }
+
+        *current_tick_index = if (zero_for_one && !tick_state.has_limit_orders())
+            || (!zero_for_one && tick_state.has_limit_orders())
+        {
+            tick_state.tick - 1
+        } else {
+            tick_state.tick
+        };
+        Ok(())
+    }
+
     #[inline(always)]
     fn matches_tick_array(&self, tick_array: &TickArrayState) -> bool {
-        let tick_array_pool_id = tick_array.pool_id;
-        let tick_array_start_tick_index = tick_array.start_tick_index;
-        let tick_array_recent_epoch = tick_array.recent_epoch;
+        let tick_array_pool_id =
+            unsafe { core::ptr::addr_of!((*tick_array).pool_id).read_unaligned() };
+        let tick_array_start_tick_index =
+            unsafe { core::ptr::addr_of!((*tick_array).start_tick_index).read_unaligned() };
+        let tick_array_recent_epoch =
+            unsafe { core::ptr::addr_of!((*tick_array).recent_epoch).read_unaligned() };
         self.pool_id == tick_array_pool_id
             && self.start_tick_index == tick_array_start_tick_index
             && self.recent_epoch == tick_array_recent_epoch
@@ -1281,11 +1384,17 @@ impl TickArrayQuoteCache {
         index: usize,
     ) -> Option<(TickState, CachedTickQuote)> {
         let tick = self.initialized_ticks.get(index)?;
-        let tick_state = unsafe {
-            let ticks = core::ptr::addr_of!(tick_array.ticks) as *const TickState;
-            ticks.add(tick.tick_offset).read_unaligned()
-        };
+        let tick_state = read_tick_unaligned(tick_array, tick.tick_offset);
         Some((tick_state, tick.quote))
+    }
+}
+
+#[inline(always)]
+fn read_tick_unaligned(tick_array: &TickArrayState, tick_offset: usize) -> TickState {
+    debug_assert!(tick_offset < TICK_ARRAY_SIZE_USIZE);
+    unsafe {
+        let ticks = core::ptr::addr_of!((*tick_array).ticks) as *const TickState;
+        ticks.add(tick_offset).read_unaligned()
     }
 }
 
@@ -1448,7 +1557,10 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
         let mut cached_tick_quote = None;
         let mut next_initialized_tick = {
             if let Some(cache) = tick_array_quote_cache_current {
-                let index = if let Some(index) = tick_array_quote_cursor {
+                let index = if !first_tick_array_contains_pool_tick {
+                    first_tick_array_contains_pool_tick = true;
+                    cache.first_initialized_tick_index(zero_for_one)
+                } else if let Some(index) = tick_array_quote_cursor {
                     Some(index)
                 } else {
                     cache.next_initialized_tick_index(state.tick, zero_for_one)
@@ -1468,18 +1580,6 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
                     zero_for_one,
                 )? {
                     *tick_state
-                } else if !first_tick_array_contains_pool_tick {
-                    first_tick_array_contains_pool_tick = true;
-                    if let Some((tick_state, tick_quote)) =
-                        tick_array_quote_cache_current.and_then(|cache| {
-                            cache.first_initialized_tick(tick_array_current, zero_for_one)
-                        })
-                    {
-                        cached_tick_quote = Some(tick_quote);
-                        tick_state
-                    } else {
-                        *tick_array_current.first_initialized_tick(zero_for_one)?
-                    }
                 } else {
                     let next_tick_array_index = pool_state
                         .next_initialized_tick_array_start_index(
@@ -1529,16 +1629,7 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
                 *tick_state
             } else if !first_tick_array_contains_pool_tick {
                 first_tick_array_contains_pool_tick = true;
-                if let Some((tick_state, tick_quote)) =
-                    tick_array_quote_cache_current.and_then(|cache| {
-                        cache.first_initialized_tick(tick_array_current, zero_for_one)
-                    })
-                {
-                    cached_tick_quote = Some(tick_quote);
-                    tick_state
-                } else {
-                    *tick_array_current.first_initialized_tick(zero_for_one)?
-                }
+                *tick_array_current.first_initialized_tick(zero_for_one)?
             } else {
                 let next_tick_array_index = pool_state
                     .next_initialized_tick_array_start_index(
@@ -1591,7 +1682,10 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
 
             let is_price_change = state.sqrt_price_x64 != bounded_price;
             let swap_computed_result = if is_price_change {
-                let swap_computed_result = swap_math::compute_swap(
+                let cached_swap_step_amounts = cached_tick_quote
+                    .and_then(|tick_quote| tick_quote.swap_step_amounts)
+                    .filter(|cached| cached.sqrt_price_target_x64 == bounded_price);
+                let swap_computed_result = swap_math::compute_swap_with_cached_amounts(
                     state.sqrt_price_x64,
                     bounded_price,
                     state.liquidity,
@@ -1600,6 +1694,7 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
                     is_base_input,
                     zero_for_one,
                     is_fee_on_input,
+                    cached_swap_step_amounts,
                 )?;
                 if POPULATE_FEE_ACCUMULATORS {
                     state.apply_swap_amounts(

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -1116,35 +1116,6 @@ pub fn swap<'info>(
     Ok(())
 }
 
-/// Off-chain quote-path mirror of `swap_internal`. Same swap math, but doesn't mutate
-/// `pool_state`, observation state, or tick array accounts — operates on references and
-/// returns the final `SwapState` plus `(amount_0, amount_1)`. Limit-order fills, dynamic fee,
-/// and `fee_on` are all handled identically to the on-chain version.
-pub fn swap_on_swap_state(
-    amm_config: &AmmConfig,
-    pool_state: &PoolState,
-    tick_array_states: VecDeque<&TickArrayState>,
-    tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
-    amount_specified: u64,
-    sqrt_price_limit_x64: u128,
-    zero_for_one: bool,
-    is_base_input: bool,
-    block_timestamp: u64,
-) -> Result<(SwapState, u64, u64)> {
-    swap_on_swap_state_with_cache(
-        amm_config,
-        pool_state,
-        tick_array_states,
-        tickarray_bitmap_extension,
-        amount_specified,
-        sqrt_price_limit_x64,
-        zero_for_one,
-        is_base_input,
-        block_timestamp,
-        None,
-    )
-}
-
 #[derive(Clone)]
 pub struct TickArrayQuoteCache {
     pool_id: Pubkey,
@@ -1415,59 +1386,13 @@ fn read_tick_unaligned(tick_array: &TickArrayState, tick_offset: usize) -> TickS
 ///       * No `tick_array_current.update_initialized_tick_count` / `flip_tick_array_bit` /
 ///         `update_tick_state` — tick array state isn't mutated
 ///       * No `require_keys_eq!` / `require_eq!` checks against pool/account identity
+///       * Quote-only: uses `apply_quote_amounts` (no `spilt_fees`), so protocol/fund/lp fee
+///         accumulators are not populated; `(amount_0, amount_1)` are still faithful
+///
+/// When `quote_caches` matches the live tick arrays, per-tick math (sqrt price, range amounts,
+/// limit-order price/unfilled) is reused from the precomputed cache; any mismatch falls back to
+/// the original on-the-fly math.
 pub fn swap_on_swap_state_with_cache(
-    amm_config: &AmmConfig,
-    pool_state: &PoolState,
-    tick_array_states: VecDeque<&TickArrayState>,
-    tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
-    amount_specified: u64,
-    sqrt_price_limit_x64: u128,
-    zero_for_one: bool,
-    is_base_input: bool,
-    block_timestamp: u64,
-    quote_caches: Option<&[TickArrayQuoteCache]>,
-) -> Result<(SwapState, u64, u64)> {
-    swap_on_swap_state_with_cache_inner::<true>(
-        amm_config,
-        pool_state,
-        tick_array_states,
-        tickarray_bitmap_extension,
-        amount_specified,
-        sqrt_price_limit_x64,
-        zero_for_one,
-        is_base_input,
-        block_timestamp,
-        quote_caches,
-    )
-}
-
-pub fn swap_on_swap_state_quote_with_cache(
-    amm_config: &AmmConfig,
-    pool_state: &PoolState,
-    tick_array_states: VecDeque<&TickArrayState>,
-    tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
-    amount_specified: u64,
-    sqrt_price_limit_x64: u128,
-    zero_for_one: bool,
-    is_base_input: bool,
-    block_timestamp: u64,
-    quote_caches: Option<&[TickArrayQuoteCache]>,
-) -> Result<(SwapState, u64, u64)> {
-    swap_on_swap_state_with_cache_inner::<false>(
-        amm_config,
-        pool_state,
-        tick_array_states,
-        tickarray_bitmap_extension,
-        amount_specified,
-        sqrt_price_limit_x64,
-        zero_for_one,
-        is_base_input,
-        block_timestamp,
-        quote_caches,
-    )
-}
-
-fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
     amm_config: &AmmConfig,
     pool_state: &PoolState,
     mut tick_array_states: VecDeque<&TickArrayState>,
@@ -1696,25 +1621,13 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
                     is_fee_on_input,
                     cached_swap_step_amounts,
                 )?;
-                if POPULATE_FEE_ACCUMULATORS {
-                    state.apply_swap_amounts(
-                        swap_computed_result.amount_in,
-                        swap_computed_result.amount_out,
-                        swap_computed_result.fee_amount,
-                        is_base_input,
-                        is_fee_on_input,
-                        amm_config.protocol_fee_rate,
-                        amm_config.fund_fee_rate,
-                    )?;
-                } else {
-                    state.apply_quote_amounts(
-                        swap_computed_result.amount_in,
-                        swap_computed_result.amount_out,
-                        swap_computed_result.fee_amount,
-                        is_base_input,
-                        is_fee_on_input,
-                    )?;
-                }
+                state.apply_quote_amounts(
+                    swap_computed_result.amount_in,
+                    swap_computed_result.amount_out,
+                    swap_computed_result.fee_amount,
+                    is_base_input,
+                    is_fee_on_input,
+                )?;
                 swap_computed_result
             } else {
                 swap_math::SwapComputationResult::new(bounded_price)
@@ -1750,25 +1663,13 @@ fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
                     || limit_order_result.amount_out != 0
                     || limit_order_result.amm_fee_amount != 0
                 {
-                    if POPULATE_FEE_ACCUMULATORS {
-                        state.apply_swap_amounts(
-                            limit_order_result.amount_in,
-                            limit_order_result.amount_out,
-                            limit_order_result.amm_fee_amount,
-                            is_base_input,
-                            is_fee_on_input,
-                            amm_config.protocol_fee_rate,
-                            amm_config.fund_fee_rate,
-                        )?;
-                    } else {
-                        state.apply_quote_amounts(
-                            limit_order_result.amount_in,
-                            limit_order_result.amount_out,
-                            limit_order_result.amm_fee_amount,
-                            is_base_input,
-                            is_fee_on_input,
-                        )?;
-                    }
+                    state.apply_quote_amounts(
+                        limit_order_result.amount_in,
+                        limit_order_result.amount_out,
+                        limit_order_result.amm_fee_amount,
+                        is_base_input,
+                        is_fee_on_input,
+                    )?;
                 }
 
                 // Quote-path: skip `tick_array_current.update_initialized_tick_count(false)` and

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -7,7 +7,7 @@ use crate::util::*;
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{Token, TokenAccount};
 use std::cell::RefMut;
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 #[cfg(feature = "enable-log")]
 use std::convert::identity;
 use std::ops::Neg;
@@ -226,6 +226,44 @@ impl SwapState {
         Ok(())
     }
 
+    pub fn apply_quote_amounts(
+        &mut self,
+        amount_in: u64,
+        amount_out: u64,
+        fee_amount: u64,
+        is_base_input: bool,
+        is_fee_on_input: bool,
+    ) -> Result<()> {
+        let amount_in_consumed = if is_fee_on_input {
+            amount_in
+                .checked_add(fee_amount)
+                .ok_or(ErrorCode::CalculateOverflow)?
+        } else {
+            amount_in
+        };
+
+        if is_base_input {
+            self.amount_specified_remaining = self
+                .amount_specified_remaining
+                .checked_sub(amount_in_consumed)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+            self.amount_calculated = self
+                .amount_calculated
+                .checked_add(amount_out)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+        } else {
+            self.amount_specified_remaining = self
+                .amount_specified_remaining
+                .checked_sub(amount_out)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+            self.amount_calculated = self
+                .amount_calculated
+                .checked_add(amount_in_consumed)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+        }
+        Ok(())
+    }
+
     pub fn spilt_fees(
         &mut self,
         fee_amont: u64,
@@ -330,6 +368,21 @@ impl SwapState {
         zero_for_one: bool,
         sqrt_price_limit_x64: u128,
     ) -> Result<u128> {
+        self.get_target_price_based_on_next_tick_with_sqrt_price(
+            tick_next,
+            zero_for_one,
+            sqrt_price_limit_x64,
+            None,
+        )
+    }
+
+    fn get_target_price_based_on_next_tick_with_sqrt_price(
+        &mut self,
+        tick_next: i32,
+        zero_for_one: bool,
+        sqrt_price_limit_x64: u128,
+        cached_sqrt_price_next_x64: Option<u128>,
+    ) -> Result<u128> {
         // Clamp tick_next to valid range
         self.tick_next = tick_next;
         if self.tick_next < tick_math::MIN_TICK {
@@ -339,7 +392,10 @@ impl SwapState {
         }
 
         // Calculate sqrt_price for the next tick
-        self.sqrt_price_next_x64 = tick_math::get_sqrt_price_at_tick(self.tick_next)?;
+        self.sqrt_price_next_x64 = match cached_sqrt_price_next_x64 {
+            Some(sqrt_price_next_x64) if self.tick_next == tick_next => sqrt_price_next_x64,
+            _ => tick_math::get_sqrt_price_at_tick(self.tick_next)?,
+        };
 
         // Determine target price: either the next tick price or the limit price
         let target_price = if (zero_for_one && self.sqrt_price_next_x64 < sqrt_price_limit_x64)
@@ -1089,52 +1145,148 @@ pub fn swap_on_swap_state(
     )
 }
 
-#[derive(Default)]
-pub struct SwapQuoteCache {
-    tick_masks: HashMap<(Pubkey, i32), TickArrayMaskCache>,
-}
-
-#[derive(Default, Clone, Copy)]
-struct TickArrayMaskCache {
-    mask: u64,
+#[derive(Clone)]
+pub struct TickArrayQuoteCache {
+    pool_id: Pubkey,
+    start_tick_index: i32,
     recent_epoch: u64,
+    initialized_ticks: Vec<CachedInitializedTick>,
 }
 
-impl SwapQuoteCache {
+#[derive(Clone, Copy)]
+struct CachedInitializedTick {
+    tick_index: i32,
+    tick_offset: usize,
+    quote: CachedTickQuote,
+}
+
+#[derive(Clone, Copy)]
+struct CachedTickQuote {
+    tick: i32,
+    sqrt_price_x64: u128,
+    price_x64_down: U128,
+    price_x64_up: U128,
+    total_unfilled_amount: u64,
+}
+
+impl CachedTickQuote {
     #[inline(always)]
-    fn mask_for(&mut self, tick_array: &TickArrayState) -> u64 {
-        let key = (tick_array.pool_id, tick_array.start_tick_index);
-        let entry = self
-            .tick_masks
-            .entry(key)
-            .or_insert_with(|| TickArrayMaskCache {
-                mask: build_initialized_mask(tick_array),
-                recent_epoch: tick_array.recent_epoch,
-            });
-
-        if entry.recent_epoch != tick_array.recent_epoch {
-            entry.mask = build_initialized_mask(tick_array);
-            entry.recent_epoch = tick_array.recent_epoch;
+    fn price_x64(self, round_up: bool) -> U128 {
+        if round_up {
+            self.price_x64_up
+        } else {
+            self.price_x64_down
         }
-
-        entry.mask
     }
 }
 
-#[inline(always)]
-fn build_initialized_mask(tick_array: &TickArrayState) -> u64 {
-    if tick_array.initialized_tick_count == 0 {
-        return 0;
-    }
-    let mut mask: u64 = 0;
-    let mut i: usize = 0;
-    while i < crate::states::tick_array::TICK_ARRAY_SIZE_USIZE {
-        if tick_array.ticks[i].is_initialized() {
-            mask |= 1u64 << i;
+impl TickArrayQuoteCache {
+    pub fn from_tick_array(tick_array: &TickArrayState) -> Result<Self> {
+        let mut cache = Self {
+            pool_id: tick_array.pool_id,
+            start_tick_index: tick_array.start_tick_index,
+            recent_epoch: tick_array.recent_epoch,
+            initialized_ticks: Vec::with_capacity(tick_array.initialized_tick_count as usize),
+        };
+
+        for (tick_offset, tick) in tick_array.ticks.iter().enumerate() {
+            if !tick.is_initialized() {
+                continue;
+            }
+            let tick_index = tick.tick;
+            let sqrt_price_x64 = tick_math::get_sqrt_price_at_tick(tick.tick)?;
+            cache.initialized_ticks.push(CachedInitializedTick {
+                tick_index,
+                tick_offset,
+                quote: CachedTickQuote {
+                    tick: tick.tick,
+                    sqrt_price_x64,
+                    price_x64_down: tick_math::get_price_from_sqrt_price_x64(
+                        sqrt_price_x64,
+                        false,
+                    )?,
+                    price_x64_up: tick_math::get_price_from_sqrt_price_x64(sqrt_price_x64, true)?,
+                    total_unfilled_amount: tick.limit_order_unfilled_amount()?,
+                },
+            });
         }
-        i += 1;
+        Ok(cache)
     }
-    mask
+
+    #[inline(always)]
+    fn matches_tick_array(&self, tick_array: &TickArrayState) -> bool {
+        let tick_array_pool_id = tick_array.pool_id;
+        let tick_array_start_tick_index = tick_array.start_tick_index;
+        let tick_array_recent_epoch = tick_array.recent_epoch;
+        self.pool_id == tick_array_pool_id
+            && self.start_tick_index == tick_array_start_tick_index
+            && self.recent_epoch == tick_array_recent_epoch
+    }
+
+    #[inline(always)]
+    fn first_initialized_tick(
+        &self,
+        tick_array: &TickArrayState,
+        zero_for_one: bool,
+    ) -> Option<(TickState, CachedTickQuote)> {
+        self.first_initialized_tick_index(zero_for_one)
+            .and_then(|index| self.tick_at(tick_array, index))
+    }
+
+    #[inline(always)]
+    fn first_initialized_tick_index(&self, zero_for_one: bool) -> Option<usize> {
+        if self.initialized_ticks.is_empty() {
+            None
+        } else if zero_for_one {
+            Some(self.initialized_ticks.len() - 1)
+        } else {
+            Some(0)
+        }
+    }
+
+    #[inline(always)]
+    fn next_initialized_tick_index(
+        &self,
+        current_tick_index: i32,
+        zero_for_one: bool,
+    ) -> Option<usize> {
+        let offset = self
+            .initialized_ticks
+            .partition_point(|tick| tick.tick_index <= current_tick_index);
+        if zero_for_one {
+            if offset == 0 {
+                None
+            } else {
+                Some(offset - 1)
+            }
+        } else {
+            (offset < self.initialized_ticks.len()).then_some(offset)
+        }
+    }
+
+    #[inline(always)]
+    fn next_cursor_index(&self, index: usize, zero_for_one: bool) -> Option<usize> {
+        if zero_for_one {
+            index.checked_sub(1)
+        } else {
+            let index = index + 1;
+            (index < self.initialized_ticks.len()).then_some(index)
+        }
+    }
+
+    #[inline(always)]
+    fn tick_at(
+        &self,
+        tick_array: &TickArrayState,
+        index: usize,
+    ) -> Option<(TickState, CachedTickQuote)> {
+        let tick = self.initialized_ticks.get(index)?;
+        let tick_state = unsafe {
+            let ticks = core::ptr::addr_of!(tick_array.ticks) as *const TickState;
+            ticks.add(tick.tick_offset).read_unaligned()
+        };
+        Some((tick_state, tick.quote))
+    }
 }
 
 /// Quote-path mirror of `swap_internal`. Side-by-side comparison invariants:
@@ -1157,6 +1309,58 @@ fn build_initialized_mask(tick_array: &TickArrayState) -> u64 {
 pub fn swap_on_swap_state_with_cache(
     amm_config: &AmmConfig,
     pool_state: &PoolState,
+    tick_array_states: VecDeque<&TickArrayState>,
+    tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
+    amount_specified: u64,
+    sqrt_price_limit_x64: u128,
+    zero_for_one: bool,
+    is_base_input: bool,
+    block_timestamp: u64,
+    quote_caches: Option<&[TickArrayQuoteCache]>,
+) -> Result<(SwapState, u64, u64)> {
+    swap_on_swap_state_with_cache_inner::<true>(
+        amm_config,
+        pool_state,
+        tick_array_states,
+        tickarray_bitmap_extension,
+        amount_specified,
+        sqrt_price_limit_x64,
+        zero_for_one,
+        is_base_input,
+        block_timestamp,
+        quote_caches,
+    )
+}
+
+pub fn swap_on_swap_state_quote_with_cache(
+    amm_config: &AmmConfig,
+    pool_state: &PoolState,
+    tick_array_states: VecDeque<&TickArrayState>,
+    tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
+    amount_specified: u64,
+    sqrt_price_limit_x64: u128,
+    zero_for_one: bool,
+    is_base_input: bool,
+    block_timestamp: u64,
+    quote_caches: Option<&[TickArrayQuoteCache]>,
+) -> Result<(SwapState, u64, u64)> {
+    swap_on_swap_state_with_cache_inner::<false>(
+        amm_config,
+        pool_state,
+        tick_array_states,
+        tickarray_bitmap_extension,
+        amount_specified,
+        sqrt_price_limit_x64,
+        zero_for_one,
+        is_base_input,
+        block_timestamp,
+        quote_caches,
+    )
+}
+
+fn swap_on_swap_state_with_cache_inner<const POPULATE_FEE_ACCUMULATORS: bool>(
+    amm_config: &AmmConfig,
+    pool_state: &PoolState,
     mut tick_array_states: VecDeque<&TickArrayState>,
     tickarray_bitmap_extension: &Option<TickArrayBitmapExtension>,
     amount_specified: u64,
@@ -1164,7 +1368,7 @@ pub fn swap_on_swap_state_with_cache(
     zero_for_one: bool,
     is_base_input: bool,
     block_timestamp: u64,
-    mut _quote_cache: Option<&mut SwapQuoteCache>,
+    quote_caches: Option<&[TickArrayQuoteCache]>,
 ) -> Result<(SwapState, u64, u64)> {
     require!(amount_specified != 0, ErrorCode::ZeroAmountSpecified);
     if !pool_state.get_status_by_bit(PoolStatusBitIndex::Swap) {
@@ -1204,6 +1408,11 @@ pub fn swap_on_swap_state_with_cache(
     let mut tick_array_current = tick_array_states
         .pop_front()
         .ok_or(ErrorCode::NotEnoughTickArrayAccount)?;
+    let mut tick_array_cache_index = 0usize;
+    let mut tick_array_quote_cache_current = quote_caches
+        .and_then(|caches| caches.get(tick_array_cache_index))
+        .filter(|cache| cache.matches_tick_array(tick_array_current));
+    let mut tick_array_quote_cursor = None;
     for _ in 0..tick_array_states.len() {
         if tick_array_current.start_tick_index == current_valid_tick_array_start_index {
             break;
@@ -1211,6 +1420,11 @@ pub fn swap_on_swap_state_with_cache(
         tick_array_current = tick_array_states
             .pop_front()
             .ok_or(ErrorCode::NotEnoughTickArrayAccount)?;
+        tick_array_cache_index += 1;
+        tick_array_quote_cache_current = quote_caches
+            .and_then(|caches| caches.get(tick_array_cache_index))
+            .filter(|cache| cache.matches_tick_array(tick_array_current));
+        tick_array_quote_cursor = None;
     }
     // Quote-path: skip `require_keys_eq!(tick_array_current.pool_id, pool_state.key())`
     require_eq!(
@@ -1227,13 +1441,87 @@ pub fn swap_on_swap_state_with_cache(
         zero_for_one,
         block_timestamp,
     )?;
-
     while state.amount_specified_remaining != 0 && state.sqrt_price_x64 != sqrt_price_limit_x64 {
         #[cfg(feature = "enable-log")]
         msg!("begin, is_base_input:{}, state.liquidity:{}, state.tick:{}, state.sqrt_price_x64:{}, state.tick_spacing_index:{}", is_base_input, state.liquidity, state.tick, state.sqrt_price_x64, state.tick_spacing_index);
 
+        let mut cached_tick_quote = None;
         let mut next_initialized_tick = {
-            if let Some(tick_state) = tick_array_current.next_initialized_tick(
+            if let Some(cache) = tick_array_quote_cache_current {
+                let index = if let Some(index) = tick_array_quote_cursor {
+                    Some(index)
+                } else {
+                    cache.next_initialized_tick_index(state.tick, zero_for_one)
+                };
+                if let Some(index) = index {
+                    if let Some((tick_state, tick_quote)) = cache.tick_at(tick_array_current, index)
+                    {
+                        tick_array_quote_cursor = cache.next_cursor_index(index, zero_for_one);
+                        cached_tick_quote = Some(tick_quote);
+                        tick_state
+                    } else {
+                        return err!(ErrorCode::InvalidTickArray);
+                    }
+                } else if let Some(tick_state) = tick_array_current.next_initialized_tick(
+                    state.tick,
+                    pool_state.tick_spacing,
+                    zero_for_one,
+                )? {
+                    *tick_state
+                } else if !first_tick_array_contains_pool_tick {
+                    first_tick_array_contains_pool_tick = true;
+                    if let Some((tick_state, tick_quote)) =
+                        tick_array_quote_cache_current.and_then(|cache| {
+                            cache.first_initialized_tick(tick_array_current, zero_for_one)
+                        })
+                    {
+                        cached_tick_quote = Some(tick_quote);
+                        tick_state
+                    } else {
+                        *tick_array_current.first_initialized_tick(zero_for_one)?
+                    }
+                } else {
+                    let next_tick_array_index = pool_state
+                        .next_initialized_tick_array_start_index(
+                            tickarray_bitmap_extension,
+                            current_valid_tick_array_start_index,
+                            zero_for_one,
+                        )?
+                        .ok_or(ErrorCode::LiquidityInsufficient)?;
+
+                    while tick_array_current.start_tick_index != next_tick_array_index {
+                        tick_array_current = tick_array_states
+                            .pop_front()
+                            .ok_or(ErrorCode::NotEnoughTickArrayAccount)?;
+                        tick_array_cache_index += 1;
+                        tick_array_quote_cache_current = quote_caches
+                            .and_then(|caches| caches.get(tick_array_cache_index))
+                            .filter(|cache| cache.matches_tick_array(tick_array_current));
+                        tick_array_quote_cursor = None;
+                        // Quote-path: skip `require_keys_eq!(tick_array_current.pool_id, pool_state.key())`.
+                    }
+                    current_valid_tick_array_start_index = next_tick_array_index;
+
+                    if let Some(cache) = tick_array_quote_cache_current {
+                        if let Some(index) = cache.first_initialized_tick_index(zero_for_one) {
+                            if let Some((tick_state, tick_quote)) =
+                                cache.tick_at(tick_array_current, index)
+                            {
+                                tick_array_quote_cursor =
+                                    cache.next_cursor_index(index, zero_for_one);
+                                cached_tick_quote = Some(tick_quote);
+                                tick_state
+                            } else {
+                                return err!(ErrorCode::InvalidTickArray);
+                            }
+                        } else {
+                            *tick_array_current.first_initialized_tick(zero_for_one)?
+                        }
+                    } else {
+                        *tick_array_current.first_initialized_tick(zero_for_one)?
+                    }
+                }
+            } else if let Some(tick_state) = tick_array_current.next_initialized_tick(
                 state.tick,
                 pool_state.tick_spacing,
                 zero_for_one,
@@ -1241,7 +1529,16 @@ pub fn swap_on_swap_state_with_cache(
                 *tick_state
             } else if !first_tick_array_contains_pool_tick {
                 first_tick_array_contains_pool_tick = true;
-                *tick_array_current.first_initialized_tick(zero_for_one)?
+                if let Some((tick_state, tick_quote)) =
+                    tick_array_quote_cache_current.and_then(|cache| {
+                        cache.first_initialized_tick(tick_array_current, zero_for_one)
+                    })
+                {
+                    cached_tick_quote = Some(tick_quote);
+                    tick_state
+                } else {
+                    *tick_array_current.first_initialized_tick(zero_for_one)?
+                }
             } else {
                 let next_tick_array_index = pool_state
                     .next_initialized_tick_array_start_index(
@@ -1255,19 +1552,34 @@ pub fn swap_on_swap_state_with_cache(
                     tick_array_current = tick_array_states
                         .pop_front()
                         .ok_or(ErrorCode::NotEnoughTickArrayAccount)?;
+                    tick_array_cache_index += 1;
+                    tick_array_quote_cache_current = quote_caches
+                        .and_then(|caches| caches.get(tick_array_cache_index))
+                        .filter(|cache| cache.matches_tick_array(tick_array_current));
+                    tick_array_quote_cursor = None;
                     // Quote-path: skip `require_keys_eq!(tick_array_current.pool_id, pool_state.key())`.
                 }
                 current_valid_tick_array_start_index = next_tick_array_index;
 
-                *tick_array_current.first_initialized_tick(zero_for_one)?
+                if let Some((tick_state, tick_quote)) =
+                    tick_array_quote_cache_current.and_then(|cache| {
+                        cache.first_initialized_tick(tick_array_current, zero_for_one)
+                    })
+                {
+                    cached_tick_quote = Some(tick_quote);
+                    tick_state
+                } else {
+                    *tick_array_current.first_initialized_tick(zero_for_one)?
+                }
             }
         };
         require_eq!(next_initialized_tick.is_initialized(), true);
 
-        let target_price = state.get_target_price_based_on_next_tick(
+        let target_price = state.get_target_price_based_on_next_tick_with_sqrt_price(
             next_initialized_tick.tick,
             zero_for_one,
             sqrt_price_limit_x64,
+            cached_tick_quote.map(|tick_quote| tick_quote.sqrt_price_x64),
         )?;
 
         let mut liquidity_next = state.liquidity;
@@ -1289,44 +1601,79 @@ pub fn swap_on_swap_state_with_cache(
                     zero_for_one,
                     is_fee_on_input,
                 )?;
-                state.apply_swap_amounts(
-                    swap_computed_result.amount_in,
-                    swap_computed_result.amount_out,
-                    swap_computed_result.fee_amount,
-                    is_base_input,
-                    is_fee_on_input,
-                    amm_config.protocol_fee_rate,
-                    amm_config.fund_fee_rate,
-                )?;
-                swap_computed_result
-            } else {
-                swap_math::SwapComputationResult::new(bounded_price)
-            };
-            let limit_order_unfilled_amount_before =
-                next_initialized_tick.limit_order_unfilled_amount()?;
-            if state.sqrt_price_next_x64 == swap_computed_result.sqrt_price_next_x64 {
-                let limit_order_result = next_initialized_tick.match_limit_order_with_sqrt_price(
-                    state.amount_specified_remaining,
-                    zero_for_one,
-                    is_base_input,
-                    total_fee_rate,
-                    is_fee_on_input,
-                    state.sqrt_price_next_x64,
-                )?;
-
-                if limit_order_result.amount_in != 0
-                    || limit_order_result.amount_out != 0
-                    || limit_order_result.amm_fee_amount != 0
-                {
+                if POPULATE_FEE_ACCUMULATORS {
                     state.apply_swap_amounts(
-                        limit_order_result.amount_in,
-                        limit_order_result.amount_out,
-                        limit_order_result.amm_fee_amount,
+                        swap_computed_result.amount_in,
+                        swap_computed_result.amount_out,
+                        swap_computed_result.fee_amount,
                         is_base_input,
                         is_fee_on_input,
                         amm_config.protocol_fee_rate,
                         amm_config.fund_fee_rate,
                     )?;
+                } else {
+                    state.apply_quote_amounts(
+                        swap_computed_result.amount_in,
+                        swap_computed_result.amount_out,
+                        swap_computed_result.fee_amount,
+                        is_base_input,
+                        is_fee_on_input,
+                    )?;
+                }
+                swap_computed_result
+            } else {
+                swap_math::SwapComputationResult::new(bounded_price)
+            };
+            let limit_order_unfilled_amount_before = if let Some(tick_quote) = cached_tick_quote {
+                tick_quote.total_unfilled_amount
+            } else {
+                next_initialized_tick.limit_order_unfilled_amount()?
+            };
+            if state.sqrt_price_next_x64 == swap_computed_result.sqrt_price_next_x64 {
+                let limit_order_result = if let Some(tick_quote) = cached_tick_quote {
+                    next_initialized_tick.match_limit_order_with_price(
+                        state.amount_specified_remaining,
+                        zero_for_one,
+                        is_base_input,
+                        total_fee_rate,
+                        is_fee_on_input,
+                        tick_quote.price_x64(!zero_for_one),
+                        tick_quote.total_unfilled_amount,
+                    )?
+                } else {
+                    next_initialized_tick.match_limit_order_with_sqrt_price(
+                        state.amount_specified_remaining,
+                        zero_for_one,
+                        is_base_input,
+                        total_fee_rate,
+                        is_fee_on_input,
+                        state.sqrt_price_next_x64,
+                    )?
+                };
+
+                if limit_order_result.amount_in != 0
+                    || limit_order_result.amount_out != 0
+                    || limit_order_result.amm_fee_amount != 0
+                {
+                    if POPULATE_FEE_ACCUMULATORS {
+                        state.apply_swap_amounts(
+                            limit_order_result.amount_in,
+                            limit_order_result.amount_out,
+                            limit_order_result.amm_fee_amount,
+                            is_base_input,
+                            is_fee_on_input,
+                            amm_config.protocol_fee_rate,
+                            amm_config.fund_fee_rate,
+                        )?;
+                    } else {
+                        state.apply_quote_amounts(
+                            limit_order_result.amount_in,
+                            limit_order_result.amount_out,
+                            limit_order_result.amm_fee_amount,
+                            is_base_input,
+                            is_fee_on_input,
+                        )?;
+                    }
                 }
 
                 // Quote-path: skip `tick_array_current.update_initialized_tick_count(false)` and

--- a/programs/amm/src/instructions/swap.rs
+++ b/programs/amm/src/instructions/swap.rs
@@ -1118,9 +1118,7 @@ pub fn swap<'info>(
 
 #[derive(Clone)]
 pub struct TickArrayQuoteCache {
-    pool_id: Pubkey,
     start_tick_index: i32,
-    recent_epoch: u64,
     initialized_ticks: Vec<CachedInitializedTick>,
 }
 
@@ -1153,17 +1151,12 @@ impl CachedTickQuote {
 
 impl TickArrayQuoteCache {
     pub fn from_tick_array(tick_array: &TickArrayState) -> Result<Self> {
-        let pool_id = unsafe { core::ptr::addr_of!((*tick_array).pool_id).read_unaligned() };
         let start_tick_index =
             unsafe { core::ptr::addr_of!((*tick_array).start_tick_index).read_unaligned() };
-        let recent_epoch =
-            unsafe { core::ptr::addr_of!((*tick_array).recent_epoch).read_unaligned() };
         let initialized_tick_count =
             unsafe { core::ptr::addr_of!((*tick_array).initialized_tick_count).read_unaligned() };
         let mut cache = Self {
-            pool_id,
             start_tick_index,
-            recent_epoch,
             initialized_ticks: Vec::with_capacity(initialized_tick_count as usize),
         };
 
@@ -1286,15 +1279,9 @@ impl TickArrayQuoteCache {
 
     #[inline(always)]
     fn matches_tick_array(&self, tick_array: &TickArrayState) -> bool {
-        let tick_array_pool_id =
-            unsafe { core::ptr::addr_of!((*tick_array).pool_id).read_unaligned() };
         let tick_array_start_tick_index =
             unsafe { core::ptr::addr_of!((*tick_array).start_tick_index).read_unaligned() };
-        let tick_array_recent_epoch =
-            unsafe { core::ptr::addr_of!((*tick_array).recent_epoch).read_unaligned() };
-        self.pool_id == tick_array_pool_id
-            && self.start_tick_index == tick_array_start_tick_index
-            && self.recent_epoch == tick_array_recent_epoch
+        self.start_tick_index == tick_array_start_tick_index
     }
 
     #[inline(always)]

--- a/programs/amm/src/libraries/swap_math.rs
+++ b/programs/amm/src/libraries/swap_math.rs
@@ -17,6 +17,94 @@ pub struct SwapComputationResult {
     pub fee_amount: u64,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct SwapStepAmountCache {
+    pub sqrt_price_current_x64: u128,
+    pub sqrt_price_target_x64: u128,
+    pub liquidity: u128,
+    pub zero_for_one: bool,
+    pub amount_in: Option<u64>,
+    pub amount_out: Option<u64>,
+}
+
+impl SwapStepAmountCache {
+    #[inline(always)]
+    fn matches(
+        self,
+        sqrt_price_current_x64: u128,
+        sqrt_price_target_x64: u128,
+        liquidity: u128,
+        zero_for_one: bool,
+    ) -> bool {
+        self.sqrt_price_current_x64 == sqrt_price_current_x64
+            && self.sqrt_price_target_x64 == sqrt_price_target_x64
+            && self.liquidity == liquidity
+            && self.zero_for_one == zero_for_one
+    }
+
+    #[inline(always)]
+    fn amount_in(
+        self,
+        sqrt_price_current_x64: u128,
+        sqrt_price_target_x64: u128,
+        liquidity: u128,
+        zero_for_one: bool,
+    ) -> Option<Option<u64>> {
+        self.matches(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            zero_for_one,
+        )
+        .then_some(self.amount_in)
+    }
+
+    #[inline(always)]
+    fn amount_out(
+        self,
+        sqrt_price_current_x64: u128,
+        sqrt_price_target_x64: u128,
+        liquidity: u128,
+        zero_for_one: bool,
+    ) -> Option<Option<u64>> {
+        self.matches(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            zero_for_one,
+        )
+        .then_some(self.amount_out)
+    }
+}
+
+pub fn cached_swap_step_amounts(
+    sqrt_price_current_x64: u128,
+    sqrt_price_target_x64: u128,
+    liquidity: u128,
+    zero_for_one: bool,
+) -> Result<SwapStepAmountCache> {
+    Ok(SwapStepAmountCache {
+        sqrt_price_current_x64,
+        sqrt_price_target_x64,
+        liquidity,
+        zero_for_one,
+        amount_in: calculate_amount_in_range(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            zero_for_one,
+            true,
+        )?,
+        amount_out: calculate_amount_in_range(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            zero_for_one,
+            false,
+        )?,
+    })
+}
+
 impl SwapComputationResult {
     pub fn new(sqrt_price_next_x64: u128) -> Self {
         Self {
@@ -42,6 +130,30 @@ pub fn compute_swap(
     zero_for_one: bool,
     is_fee_on_input: bool,
 ) -> Result<SwapComputationResult> {
+    compute_swap_with_cached_amounts(
+        sqrt_price_current_x64,
+        sqrt_price_target_x64,
+        liquidity,
+        amount_remaining,
+        fee_rate,
+        is_base_input,
+        zero_for_one,
+        is_fee_on_input,
+        None,
+    )
+}
+
+pub fn compute_swap_with_cached_amounts(
+    sqrt_price_current_x64: u128,
+    sqrt_price_target_x64: u128,
+    liquidity: u128,
+    amount_remaining: u64,
+    fee_rate: u32,
+    is_base_input: bool,
+    zero_for_one: bool,
+    is_fee_on_input: bool,
+    cached_amounts: Option<SwapStepAmountCache>,
+) -> Result<SwapComputationResult> {
     let mut result = SwapComputationResult::default();
     if is_base_input {
         let amount_for_price_calc = if is_fee_on_input {
@@ -56,13 +168,24 @@ pub fn compute_swap(
             amount_remaining
         };
 
-        let amount_in = calculate_amount_in_range(
-            sqrt_price_current_x64,
-            sqrt_price_target_x64,
-            liquidity,
-            zero_for_one,
-            is_base_input,
-        )?;
+        let amount_in = if let Some(amount_in) = cached_amounts.and_then(|cached| {
+            cached.amount_in(
+                sqrt_price_current_x64,
+                sqrt_price_target_x64,
+                liquidity,
+                zero_for_one,
+            )
+        }) {
+            amount_in
+        } else {
+            calculate_amount_in_range(
+                sqrt_price_current_x64,
+                sqrt_price_target_x64,
+                liquidity,
+                zero_for_one,
+                is_base_input,
+            )?
+        };
         if let Some(v) = amount_in {
             result.amount_in = v;
         }
@@ -93,13 +216,24 @@ pub fn compute_swap(
                 .ok_or(ErrorCode::CalculateOverflow)?
         };
 
-        let amount_out = calculate_amount_in_range(
-            sqrt_price_current_x64,
-            sqrt_price_target_x64,
-            liquidity,
-            zero_for_one,
-            is_base_input,
-        )?;
+        let amount_out = if let Some(amount_out) = cached_amounts.and_then(|cached| {
+            cached.amount_out(
+                sqrt_price_current_x64,
+                sqrt_price_target_x64,
+                liquidity,
+                zero_for_one,
+            )
+        }) {
+            amount_out
+        } else {
+            calculate_amount_in_range(
+                sqrt_price_current_x64,
+                sqrt_price_target_x64,
+                liquidity,
+                zero_for_one,
+                is_base_input,
+            )?
+        };
         if let Some(v) = amount_out {
             result.amount_out = v;
         }
@@ -128,38 +262,130 @@ pub fn compute_swap(
     if zero_for_one {
         // if max is reached for exact input case, entire amount_in is needed
         if !(max && is_base_input) {
-            result.amount_in = liquidity_math::get_delta_amount_0_unsigned(
-                result.sqrt_price_next_x64,
-                sqrt_price_current_x64,
-                liquidity,
-                true,
-            )?
+            result.amount_in = if max {
+                cached_amounts
+                    .and_then(|cached| {
+                        cached
+                            .amount_in(
+                                sqrt_price_current_x64,
+                                sqrt_price_target_x64,
+                                liquidity,
+                                zero_for_one,
+                            )
+                            .flatten()
+                    })
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        liquidity_math::get_delta_amount_0_unsigned(
+                            result.sqrt_price_next_x64,
+                            sqrt_price_current_x64,
+                            liquidity,
+                            true,
+                        )
+                    })?
+            } else {
+                liquidity_math::get_delta_amount_0_unsigned(
+                    result.sqrt_price_next_x64,
+                    sqrt_price_current_x64,
+                    liquidity,
+                    true,
+                )?
+            }
         };
         // if max is reached for exact output case, entire amount_out is needed
         if !(max && !is_base_input) {
-            result.amount_out = liquidity_math::get_delta_amount_1_unsigned(
-                result.sqrt_price_next_x64,
-                sqrt_price_current_x64,
-                liquidity,
-                false,
-            )?;
+            result.amount_out = if max {
+                cached_amounts
+                    .and_then(|cached| {
+                        cached
+                            .amount_out(
+                                sqrt_price_current_x64,
+                                sqrt_price_target_x64,
+                                liquidity,
+                                zero_for_one,
+                            )
+                            .flatten()
+                    })
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        liquidity_math::get_delta_amount_1_unsigned(
+                            result.sqrt_price_next_x64,
+                            sqrt_price_current_x64,
+                            liquidity,
+                            false,
+                        )
+                    })?
+            } else {
+                liquidity_math::get_delta_amount_1_unsigned(
+                    result.sqrt_price_next_x64,
+                    sqrt_price_current_x64,
+                    liquidity,
+                    false,
+                )?
+            };
         };
     } else {
         if !(max && is_base_input) {
-            result.amount_in = liquidity_math::get_delta_amount_1_unsigned(
-                sqrt_price_current_x64,
-                result.sqrt_price_next_x64,
-                liquidity,
-                true,
-            )?
+            result.amount_in = if max {
+                cached_amounts
+                    .and_then(|cached| {
+                        cached
+                            .amount_in(
+                                sqrt_price_current_x64,
+                                sqrt_price_target_x64,
+                                liquidity,
+                                zero_for_one,
+                            )
+                            .flatten()
+                    })
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        liquidity_math::get_delta_amount_1_unsigned(
+                            sqrt_price_current_x64,
+                            result.sqrt_price_next_x64,
+                            liquidity,
+                            true,
+                        )
+                    })?
+            } else {
+                liquidity_math::get_delta_amount_1_unsigned(
+                    sqrt_price_current_x64,
+                    result.sqrt_price_next_x64,
+                    liquidity,
+                    true,
+                )?
+            }
         };
         if !(max && !is_base_input) {
-            result.amount_out = liquidity_math::get_delta_amount_0_unsigned(
-                sqrt_price_current_x64,
-                result.sqrt_price_next_x64,
-                liquidity,
-                false,
-            )?
+            result.amount_out = if max {
+                cached_amounts
+                    .and_then(|cached| {
+                        cached
+                            .amount_out(
+                                sqrt_price_current_x64,
+                                sqrt_price_target_x64,
+                                liquidity,
+                                zero_for_one,
+                            )
+                            .flatten()
+                    })
+                    .map(Ok)
+                    .unwrap_or_else(|| {
+                        liquidity_math::get_delta_amount_0_unsigned(
+                            sqrt_price_current_x64,
+                            result.sqrt_price_next_x64,
+                            liquidity,
+                            false,
+                        )
+                    })?
+            } else {
+                liquidity_math::get_delta_amount_0_unsigned(
+                    sqrt_price_current_x64,
+                    result.sqrt_price_next_x64,
+                    liquidity,
+                    false,
+                )?
+            }
         };
     }
 
@@ -314,5 +540,94 @@ fn calculate_amount_in_range(
         Ok(v) => Ok(Some(v)),
         Err(e) if e == ErrorCode::MaxTokenOverflow.into() => Ok(None),
         Err(_) => Err(ErrorCode::SqrtPriceLimitOverflow.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::libraries::tick_math;
+
+    fn assert_same_swap(
+        sqrt_price_current_x64: u128,
+        sqrt_price_target_x64: u128,
+        liquidity: u128,
+        amount_remaining: u64,
+        fee_rate: u32,
+        is_base_input: bool,
+        zero_for_one: bool,
+        is_fee_on_input: bool,
+    ) -> Result<()> {
+        let cached_amounts = cached_swap_step_amounts(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            zero_for_one,
+        )?;
+        let uncached = compute_swap(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            amount_remaining,
+            fee_rate,
+            is_base_input,
+            zero_for_one,
+            is_fee_on_input,
+        )?;
+        let cached = compute_swap_with_cached_amounts(
+            sqrt_price_current_x64,
+            sqrt_price_target_x64,
+            liquidity,
+            amount_remaining,
+            fee_rate,
+            is_base_input,
+            zero_for_one,
+            is_fee_on_input,
+            Some(cached_amounts),
+        )?;
+
+        assert_eq!(uncached.sqrt_price_next_x64, cached.sqrt_price_next_x64);
+        assert_eq!(uncached.amount_in, cached.amount_in);
+        assert_eq!(uncached.amount_out, cached.amount_out);
+        assert_eq!(uncached.fee_amount, cached.fee_amount);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_swap_step_amounts_match_uncached_compute_swap() -> Result<()> {
+        let liquidity = 1_000_000_000_000_000u128;
+        let amount_remaining = 1_000_000_000_000_000u64;
+        let fee_rate = 2_500u32;
+
+        for zero_for_one in [true, false] {
+            let (sqrt_price_current_x64, sqrt_price_target_x64) = if zero_for_one {
+                (
+                    tick_math::get_sqrt_price_at_tick(100)?,
+                    tick_math::get_sqrt_price_at_tick(0)?,
+                )
+            } else {
+                (
+                    tick_math::get_sqrt_price_at_tick(0)?,
+                    tick_math::get_sqrt_price_at_tick(100)?,
+                )
+            };
+
+            for is_base_input in [true, false] {
+                for is_fee_on_input in [true, false] {
+                    assert_same_swap(
+                        sqrt_price_current_x64,
+                        sqrt_price_target_x64,
+                        liquidity,
+                        amount_remaining,
+                        fee_rate,
+                        is_base_input,
+                        zero_for_one,
+                        is_fee_on_input,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/programs/amm/src/libraries/tick_math.rs
+++ b/programs/amm/src/libraries/tick_math.rs
@@ -204,6 +204,17 @@ pub fn get_price_from_sqrt_price_x64(
     token_0_sqrt_price: u128,
     round_up: bool,
 ) -> Result<U128, anchor_lang::error::Error> {
+    if token_0_sqrt_price <= u128::from(u64::MAX) {
+        let square = token_0_sqrt_price * token_0_sqrt_price;
+        let mut token_0_price = square >> fixed_point_64::RESOLUTION;
+        if round_up && (square & (u128::from(fixed_point_64::Q64) - 1)) != 0 {
+            token_0_price = token_0_price
+                .checked_add(1)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+        }
+        return Ok(U128::from(token_0_price));
+    }
+
     let square = U256::from(token_0_sqrt_price) * U256::from(token_0_sqrt_price);
     let mut token_0_price = square >> fixed_point_64::RESOLUTION;
     if round_up && square.0[0] != 0 {

--- a/programs/amm/src/libraries/tick_math.rs
+++ b/programs/amm/src/libraries/tick_math.rs
@@ -1,6 +1,9 @@
 use crate::{
     error::ErrorCode,
-    libraries::{big_num::U128, fixed_point_64, full_math::MulDiv},
+    libraries::{
+        big_num::{U128, U256},
+        fixed_point_64,
+    },
 };
 
 use anchor_lang::require;
@@ -194,27 +197,113 @@ pub fn get_tick_at_sqrt_price(sqrt_price_x64: u128) -> Result<i32, anchor_lang::
 /// called by the Phase 3 `swap_on_swap_state` rewrite. No callers in the slim SDK yet.
 pub fn get_price_at_tick(tick: i32, round_up: bool) -> Result<U128, anchor_lang::error::Error> {
     let token_0_sqrt_price = get_sqrt_price_at_tick(tick)?;
-    let token_0_price = if round_up {
-        U128::from(token_0_sqrt_price)
-            .mul_div_ceil(
-                U128::from(token_0_sqrt_price),
-                U128::from(fixed_point_64::Q64),
-            )
-            .ok_or(ErrorCode::CalculateOverflow)?
-    } else {
-        U128::from(token_0_sqrt_price)
-            .mul_div_floor(
-                U128::from(token_0_sqrt_price),
-                U128::from(fixed_point_64::Q64),
-            )
-            .ok_or(ErrorCode::CalculateOverflow)?
-    };
-    Ok(token_0_price)
+    get_price_from_sqrt_price_x64(token_0_sqrt_price, round_up)
+}
+
+pub fn get_price_from_sqrt_price_x64(
+    token_0_sqrt_price: u128,
+    round_up: bool,
+) -> Result<U128, anchor_lang::error::Error> {
+    let square = U256::from(token_0_sqrt_price) * U256::from(token_0_sqrt_price);
+    let mut token_0_price = square >> fixed_point_64::RESOLUTION;
+    if round_up && square.0[0] != 0 {
+        token_0_price = token_0_price
+            .checked_add(U256::from(1u8))
+            .ok_or(ErrorCode::CalculateOverflow)?;
+    }
+    if token_0_price.0[2] != 0 || token_0_price.0[3] != 0 {
+        return Err(ErrorCode::CalculateOverflow.into());
+    }
+    Ok(U128([token_0_price.0[0], token_0_price.0[1]]))
 }
 
 #[cfg(test)]
 mod tick_math_test {
     use super::*;
+    use crate::libraries::full_math::MulDiv;
+
+    fn get_price_at_tick_reference(
+        tick: i32,
+        round_up: bool,
+    ) -> Result<U128, anchor_lang::error::Error> {
+        let token_0_sqrt_price = get_sqrt_price_at_tick(tick)?;
+        let token_0_price = if round_up {
+            U128::from(token_0_sqrt_price)
+                .mul_div_ceil(
+                    U128::from(token_0_sqrt_price),
+                    U128::from(fixed_point_64::Q64),
+                )
+                .ok_or(ErrorCode::CalculateOverflow)?
+        } else {
+            U128::from(token_0_sqrt_price)
+                .mul_div_floor(
+                    U128::from(token_0_sqrt_price),
+                    U128::from(fixed_point_64::Q64),
+                )
+                .ok_or(ErrorCode::CalculateOverflow)?
+        };
+        Ok(token_0_price)
+    }
+
+    #[test]
+    fn get_price_at_tick_shift_matches_generic_mul_div() {
+        let mut ticks = vec![
+            MIN_TICK,
+            MIN_TICK + 1,
+            -100_000,
+            -10_000,
+            -1,
+            0,
+            1,
+            10_000,
+            100_000,
+            MAX_TICK - 1,
+            MAX_TICK,
+        ];
+        ticks.extend((MIN_TICK..=MIN_TICK + 1_000).step_by(37));
+        ticks.extend((-1_000..=1_000).step_by(37));
+        ticks.extend((MAX_TICK - 1_000..=MAX_TICK).step_by(37));
+        ticks.extend((-443_640..=443_640).step_by(60));
+
+        for tick in ticks {
+            let tick = tick.clamp(MIN_TICK, MAX_TICK);
+            for round_up in [false, true] {
+                assert_eq!(
+                    get_price_at_tick(tick, round_up).unwrap(),
+                    get_price_at_tick_reference(tick, round_up).unwrap(),
+                    "tick={tick} round_up={round_up}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn get_price_from_sqrt_price_reports_overflow() {
+        assert!(get_price_from_sqrt_price_x64(u128::MAX, false).is_err());
+        assert!(get_price_from_sqrt_price_x64(u128::MAX, true).is_err());
+    }
+
+    #[test]
+    fn get_price_from_sqrt_price_rounds_shift_remainder() {
+        assert_eq!(
+            get_price_from_sqrt_price_x64(fixed_point_64::Q64, false).unwrap(),
+            U128::from(fixed_point_64::Q64)
+        );
+        assert_eq!(
+            get_price_from_sqrt_price_x64(fixed_point_64::Q64, true).unwrap(),
+            U128::from(fixed_point_64::Q64)
+        );
+
+        assert_eq!(
+            get_price_from_sqrt_price_x64(fixed_point_64::Q64 + 1, false).unwrap(),
+            U128::from(fixed_point_64::Q64 + 2)
+        );
+        assert_eq!(
+            get_price_from_sqrt_price_x64(fixed_point_64::Q64 + 1, true).unwrap(),
+            U128::from(fixed_point_64::Q64 + 3)
+        );
+    }
+
     mod get_sqrt_price_at_tick_test {
         use super::*;
         use crate::libraries::fixed_point_64;

--- a/programs/amm/src/states/pool_fee.rs
+++ b/programs/amm/src/states/pool_fee.rs
@@ -91,7 +91,8 @@ impl DynamicFeeInfo {
         .unsigned_abs();
         let volatility_accumulator = u64::from(self.volatility_reference)
             .checked_add(
-                index_delta.checked_mul(u64::from(VOLATILITY_ACCUMULATOR_SCALE))
+                index_delta
+                    .checked_mul(u64::from(VOLATILITY_ACCUMULATOR_SCALE))
                     .ok_or(ErrorCode::CalculateOverflow)?,
             )
             .ok_or(ErrorCode::CalculateOverflow)?;

--- a/programs/amm/src/states/tick_array.rs
+++ b/programs/amm/src/states/tick_array.rs
@@ -502,11 +502,9 @@ impl TickState {
         is_fee_on_input: bool,
         token_0_sqrt_price_x64: u128,
     ) -> Result<LimitOrderMatchResult> {
-        let mut result = LimitOrderMatchResult::default();
-
         let total_unfilled_amount = self.limit_order_unfilled_amount()?;
         if swap_amount == 0 || total_unfilled_amount == 0 {
-            return Ok(result);
+            return Ok(LimitOrderMatchResult::default());
         }
 
         #[cfg(debug_assertions)]

--- a/programs/amm/src/states/tick_array.rs
+++ b/programs/amm/src/states/tick_array.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
-use crate::libraries::{fixed_point_64, full_math::MulDiv, liquidity_math, tick_math};
 use crate::libraries::U128;
+use crate::libraries::{fixed_point_64, full_math::MulDiv, liquidity_math, tick_math};
 use crate::pool::{RewardInfo, REWARD_NUM};
 use crate::states::config::FEE_RATE_DENOMINATOR_VALUE;
 use crate::util::*;
@@ -868,15 +868,7 @@ pub mod tick_array_test {
 
     #[test]
     fn native_limit_order_math_matches_generic_mul_div() {
-        let amounts = [
-            0,
-            1,
-            7,
-            1_000,
-            u32::MAX as u64,
-            u64::MAX / 2,
-            u64::MAX,
-        ];
+        let amounts = [0, 1, 7, 1_000, u32::MAX as u64, u64::MAX / 2, u64::MAX];
         let factors = [
             U128::from(1),
             U128::from(fixed_point_64::Q64 - 1),
@@ -891,18 +883,12 @@ pub mod tick_array_test {
             for factor in factors {
                 for round_up in [false, true] {
                     let expected = if round_up {
-                        U128::from(amount)
-                            .mul_div_ceil(factor, U128::from(fixed_point_64::Q64))
+                        U128::from(amount).mul_div_ceil(factor, U128::from(fixed_point_64::Q64))
                     } else {
-                        U128::from(amount)
-                            .mul_div_floor(factor, U128::from(fixed_point_64::Q64))
+                        U128::from(amount).mul_div_floor(factor, U128::from(fixed_point_64::Q64))
                     }
                     .ok_or(ErrorCode::CalculateOverflow)
-                    .and_then(|value| {
-                        value
-                            .try_into()
-                            .map_err(|_| ErrorCode::CalculateOverflow)
-                    });
+                    .and_then(|value| value.try_into().map_err(|_| ErrorCode::CalculateOverflow));
 
                     assert!(
                         same_u64_result(
@@ -918,15 +904,7 @@ pub mod tick_array_test {
 
     #[test]
     fn native_inverse_limit_order_math_matches_generic_mul_div() {
-        let amounts = [
-            0,
-            1,
-            7,
-            1_000,
-            u32::MAX as u64,
-            u64::MAX / 2,
-            u64::MAX,
-        ];
+        let amounts = [0, 1, 7, 1_000, u32::MAX as u64, u64::MAX / 2, u64::MAX];
         let divisors = [
             U128::from(1),
             U128::from(fixed_point_64::Q64 - 1),
@@ -941,18 +919,12 @@ pub mod tick_array_test {
             for divisor in divisors {
                 for round_up in [false, true] {
                     let expected = if round_up {
-                        U128::from(amount)
-                            .mul_div_ceil(U128::from(fixed_point_64::Q64), divisor)
+                        U128::from(amount).mul_div_ceil(U128::from(fixed_point_64::Q64), divisor)
                     } else {
-                        U128::from(amount)
-                            .mul_div_floor(U128::from(fixed_point_64::Q64), divisor)
+                        U128::from(amount).mul_div_floor(U128::from(fixed_point_64::Q64), divisor)
                     }
                     .ok_or(ErrorCode::CalculateOverflow)
-                    .and_then(|value| {
-                        value
-                            .try_into()
-                            .map_err(|_| ErrorCode::CalculateOverflow)
-                    });
+                    .and_then(|value| value.try_into().map_err(|_| ErrorCode::CalculateOverflow));
 
                     assert!(
                         same_u64_result(

--- a/programs/amm/src/states/tick_array.rs
+++ b/programs/amm/src/states/tick_array.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
-use crate::libraries::U128;
 use crate::libraries::{fixed_point_64, full_math::MulDiv, liquidity_math, tick_math};
+use crate::libraries::{U128, U256};
 use crate::pool::{RewardInfo, REWARD_NUM};
 use crate::states::config::FEE_RATE_DENOMINATOR_VALUE;
 use crate::util::*;
@@ -416,17 +416,20 @@ impl TickState {
     /// zero_for_one: the direction of the input token
     /// output amount is rounded down
     pub fn get_limit_order_output(amount_in: u64, tick: i32, zero_for_one: bool) -> Result<u64> {
+        let token_0_price_x64 = tick_math::get_price_at_tick(tick, !zero_for_one)?;
+        Self::get_limit_order_output_with_price(amount_in, token_0_price_x64, zero_for_one)
+    }
+
+    fn get_limit_order_output_with_price(
+        amount_in: u64,
+        token_0_price_x64: U128,
+        zero_for_one: bool,
+    ) -> Result<u64> {
         let output_amount = if zero_for_one {
-            let token_0_price_x64 = tick_math::get_price_at_tick(tick, false)?;
             // Convert token0 amount to token1 amount using token0 price
             // token1_amount = token0_amount * token_0_price_x64 / 2^64
-            U128::from(amount_in)
-                .mul_div_floor(token_0_price_x64, U128::from(fixed_point_64::Q64))
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .try_into()
-                .map_err(|_| ErrorCode::CalculateOverflow)?
+            mul_u64_u128_shift_right_64(amount_in, token_0_price_x64, false)?
         } else {
-            let token_0_price_x64 = tick_math::get_price_at_tick(tick, true)?;
             // Convert token1 amount to token0 amount using token1 price (1/token_0_price_x64)
             // token0_amount = token1_amount * 2^64 / token_0_price_x64
             U128::from(amount_in)
@@ -444,16 +447,19 @@ impl TickState {
     /// zero_for_one: the direction of the limit order
     /// input amount is rounded up
     pub fn get_limit_order_input(amount_out: u64, tick: i32, zero_for_one: bool) -> Result<u64> {
+        let token_0_price_x64 = tick_math::get_price_at_tick(tick, zero_for_one)?;
+        Self::get_limit_order_input_with_price(amount_out, token_0_price_x64, zero_for_one)
+    }
+
+    fn get_limit_order_input_with_price(
+        amount_out: u64,
+        token_0_price_x64: U128,
+        zero_for_one: bool,
+    ) -> Result<u64> {
         let amount_in = if zero_for_one {
-            let token_0_price_x64 = tick_math::get_price_at_tick(tick, true)?;
             // token1_consumed = token0_executed * token_0_price_x64 / 2^64
-            U128::from(amount_out)
-                .mul_div_ceil(token_0_price_x64, U128::from(fixed_point_64::Q64))
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .try_into()
-                .map_err(|_| ErrorCode::CalculateOverflow)?
+            mul_u64_u128_shift_right_64(amount_out, token_0_price_x64, true)?
         } else {
-            let token_0_price_x64 = tick_math::get_price_at_tick(tick, false)?;
             // token0_consumed = token1_executed * 2^64 / token_0_price_x64
             U128::from(amount_out)
                 .mul_div_ceil(U128::from(fixed_point_64::Q64), token_0_price_x64)
@@ -480,12 +486,47 @@ impl TickState {
         fee_rate: u32,
         is_fee_on_input: bool,
     ) -> Result<LimitOrderMatchResult> {
+        let token_0_sqrt_price_x64 = tick_math::get_sqrt_price_at_tick(self.tick)?;
+        self.match_limit_order_with_sqrt_price(
+            swap_amount,
+            swap_direction_zero_for_one,
+            is_base_input,
+            fee_rate,
+            is_fee_on_input,
+            token_0_sqrt_price_x64,
+        )
+    }
+
+    /// Match limit orders using the already-computed sqrt price for `self.tick`.
+    ///
+    /// Callers must pass `tick_math::get_sqrt_price_at_tick(self.tick)`; the swap loop already
+    /// has this value as `state.sqrt_price_next_x64` when crossing an initialized tick.
+    pub fn match_limit_order_with_sqrt_price(
+        &mut self,
+        swap_amount: u64,
+        swap_direction_zero_for_one: bool,
+        is_base_input: bool,
+        fee_rate: u32,
+        is_fee_on_input: bool,
+        token_0_sqrt_price_x64: u128,
+    ) -> Result<LimitOrderMatchResult> {
         let mut result = LimitOrderMatchResult::default();
 
         let total_unfilled_amount = self.limit_order_unfilled_amount()?;
         if swap_amount == 0 || total_unfilled_amount == 0 {
             return Ok(result);
         }
+
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            tick_math::get_sqrt_price_at_tick(self.tick).ok(),
+            Some(token_0_sqrt_price_x64)
+        );
+
+        let token_0_price_x64 = tick_math::get_price_from_sqrt_price_x64(
+            token_0_sqrt_price_x64,
+            !swap_direction_zero_for_one,
+        )?;
 
         if is_base_input {
             // Assume the input amount can be fully consumed, calculate the amount of limit order tokens matched
@@ -497,18 +538,18 @@ impl TickState {
             } else {
                 result.amount_in = swap_amount;
             }
-            result.amount_out = TickState::get_limit_order_output(
+            result.amount_out = TickState::get_limit_order_output_with_price(
                 result.amount_in,
-                self.tick,
+                token_0_price_x64,
                 swap_direction_zero_for_one,
             )?;
             // If the amount of limit order tokens matched is greater than the total unfilled amount,
             // it means the input cannot be fully consumed, so recalculate the input and output amounts
             if result.amount_out > total_unfilled_amount {
                 result.amount_out = total_unfilled_amount;
-                result.amount_in = TickState::get_limit_order_input(
+                result.amount_in = TickState::get_limit_order_input_with_price(
                     total_unfilled_amount,
-                    self.tick,
+                    token_0_price_x64,
                     !swap_direction_zero_for_one,
                 )?;
                 if is_fee_on_input {
@@ -537,9 +578,9 @@ impl TickState {
                     .ok_or(ErrorCode::CalculateOverflow)?
                     .min(total_unfilled_amount)
             };
-            result.amount_in = TickState::get_limit_order_input(
+            result.amount_in = TickState::get_limit_order_input_with_price(
                 result.amount_out,
-                self.tick,
+                token_0_price_x64,
                 !swap_direction_zero_for_one,
             )?;
             if is_fee_on_input {
@@ -621,6 +662,20 @@ impl TickState {
     pub fn check_is_out_of_boundary(tick: i32) -> bool {
         tick < tick_math::MIN_TICK || tick > tick_math::MAX_TICK
     }
+}
+
+fn mul_u64_u128_shift_right_64(amount: u64, factor_x64: U128, round_up: bool) -> Result<u64> {
+    let product = U256::from(amount) * U256([factor_x64.0[0], factor_x64.0[1], 0, 0]);
+    let mut quotient = product >> fixed_point_64::RESOLUTION;
+    if round_up && product.0[0] != 0 {
+        quotient = quotient
+            .checked_add(U256::from(1u8))
+            .ok_or(ErrorCode::CalculateOverflow)?;
+    }
+    if quotient.0[1] != 0 || quotient.0[2] != 0 || quotient.0[3] != 0 {
+        return Err(ErrorCode::CalculateOverflow.into());
+    }
+    Ok(quotient.0[0])
 }
 
 // Calculates the fee growths inside of tick_lower and tick_upper based on their positions relative to tick_current.
@@ -736,6 +791,392 @@ pub mod tick_array_test {
     fn limit_order_input_overflow_returns_err_not_panic() {
         assert!(TickState::get_limit_order_input(u64::MAX, 10_000, true).is_err());
         assert!(TickState::get_limit_order_input(u64::MAX, -10_000, false).is_err());
+    }
+
+    #[test]
+    fn shifted_limit_order_math_returns_err_on_ceil_overflow() {
+        assert!(
+            mul_u64_u128_shift_right_64(u64::MAX, U128::from(fixed_point_64::Q64 + 1), true,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn shifted_limit_order_math_rounds_shift_remainder() {
+        assert_eq!(
+            mul_u64_u128_shift_right_64(7, U128::from(fixed_point_64::Q64), false).unwrap(),
+            7
+        );
+        assert_eq!(
+            mul_u64_u128_shift_right_64(7, U128::from(fixed_point_64::Q64), true).unwrap(),
+            7
+        );
+        assert_eq!(
+            mul_u64_u128_shift_right_64(1, U128::from(fixed_point_64::Q64 + 1), false).unwrap(),
+            1
+        );
+        assert_eq!(
+            mul_u64_u128_shift_right_64(1, U128::from(fixed_point_64::Q64 + 1), true).unwrap(),
+            2
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    struct LimitOrderMatchCase {
+        tick: i32,
+        swap_amount: u64,
+        zero_for_one: bool,
+        is_base_input: bool,
+        fee_rate: u32,
+        is_fee_on_input: bool,
+        orders_amount: u64,
+        part_filled_orders_remaining: u64,
+    }
+
+    #[test]
+    fn match_limit_order_reuses_price_without_changing_results() {
+        let cases = [
+            LimitOrderMatchCase {
+                tick: 0,
+                swap_amount: 0,
+                zero_for_one: true,
+                is_base_input: true,
+                fee_rate: 2_500,
+                is_fee_on_input: true,
+                orders_amount: 1_000,
+                part_filled_orders_remaining: 0,
+            },
+            LimitOrderMatchCase {
+                tick: 0,
+                swap_amount: 1_000,
+                zero_for_one: false,
+                is_base_input: false,
+                fee_rate: 2_500,
+                is_fee_on_input: false,
+                orders_amount: 0,
+                part_filled_orders_remaining: 0,
+            },
+            LimitOrderMatchCase {
+                tick: 0,
+                swap_amount: 1_000,
+                zero_for_one: true,
+                is_base_input: true,
+                fee_rate: 2_500,
+                is_fee_on_input: true,
+                orders_amount: 10_000,
+                part_filled_orders_remaining: 500,
+            },
+            LimitOrderMatchCase {
+                tick: 10_000,
+                swap_amount: 1_000_000,
+                zero_for_one: true,
+                is_base_input: true,
+                fee_rate: 2_500,
+                is_fee_on_input: false,
+                orders_amount: 100,
+                part_filled_orders_remaining: 25,
+            },
+            LimitOrderMatchCase {
+                tick: -10_000,
+                swap_amount: 1_000,
+                zero_for_one: false,
+                is_base_input: false,
+                fee_rate: 2_500,
+                is_fee_on_input: true,
+                orders_amount: 10_000,
+                part_filled_orders_remaining: 500,
+            },
+            LimitOrderMatchCase {
+                tick: 1,
+                swap_amount: 100_000,
+                zero_for_one: false,
+                is_base_input: false,
+                fee_rate: 2_500,
+                is_fee_on_input: false,
+                orders_amount: 250,
+                part_filled_orders_remaining: 25,
+            },
+            LimitOrderMatchCase {
+                tick: tick_math::MIN_TICK + 1,
+                swap_amount: 1,
+                zero_for_one: true,
+                is_base_input: false,
+                fee_rate: 1,
+                is_fee_on_input: true,
+                orders_amount: 1_000_000,
+                part_filled_orders_remaining: 0,
+            },
+            LimitOrderMatchCase {
+                tick: tick_math::MAX_TICK - 1,
+                swap_amount: 1,
+                zero_for_one: false,
+                is_base_input: true,
+                fee_rate: 1,
+                is_fee_on_input: false,
+                orders_amount: 1_000_000,
+                part_filled_orders_remaining: 0,
+            },
+        ];
+
+        for case in cases {
+            let mut old_tick = limit_order_tick(case);
+            let mut new_tick = old_tick;
+
+            let old_result = match_limit_order_reference(
+                &mut old_tick,
+                case.swap_amount,
+                case.zero_for_one,
+                case.is_base_input,
+                case.fee_rate,
+                case.is_fee_on_input,
+            );
+            let sqrt_price_x64 = tick_math::get_sqrt_price_at_tick(case.tick).unwrap();
+            let new_result = new_tick.match_limit_order_with_sqrt_price(
+                case.swap_amount,
+                case.zero_for_one,
+                case.is_base_input,
+                case.fee_rate,
+                case.is_fee_on_input,
+                sqrt_price_x64,
+            );
+
+            match (old_result, new_result) {
+                (Ok(old_result), Ok(new_result)) => {
+                    assert_eq!(
+                        limit_order_result_tuple(old_result),
+                        limit_order_result_tuple(new_result)
+                    );
+                    assert_eq!(
+                        limit_order_state_tuple(&old_tick),
+                        limit_order_state_tuple(&new_tick)
+                    );
+                }
+                (Err(old_error), Err(new_error)) => {
+                    assert_eq!(format!("{old_error:?}"), format!("{new_error:?}"));
+                }
+                (old_result, new_result) => {
+                    panic!(
+                        "mismatched result for tick {}: old={old_result:?} new={new_result:?}",
+                        case.tick
+                    )
+                }
+            }
+        }
+    }
+
+    fn limit_order_tick(case: LimitOrderMatchCase) -> TickState {
+        let mut tick = TickState::default();
+        tick.tick = case.tick;
+        tick.orders_amount = case.orders_amount;
+        tick.part_filled_orders_remaining = case.part_filled_orders_remaining;
+        tick.unfilled_ratio_x64 = u128::from(fixed_point_64::Q64);
+        tick
+    }
+
+    fn limit_order_result_tuple(result: LimitOrderMatchResult) -> (u64, u64, u64) {
+        (result.amount_in, result.amount_out, result.amm_fee_amount)
+    }
+
+    fn limit_order_state_tuple(tick: &TickState) -> (u64, u64, u128, u64) {
+        (
+            tick.orders_amount,
+            tick.part_filled_orders_remaining,
+            tick.unfilled_ratio_x64,
+            tick.order_phase,
+        )
+    }
+
+    fn match_limit_order_reference(
+        tick: &mut TickState,
+        swap_amount: u64,
+        swap_direction_zero_for_one: bool,
+        is_base_input: bool,
+        fee_rate: u32,
+        is_fee_on_input: bool,
+    ) -> Result<LimitOrderMatchResult> {
+        let mut result = LimitOrderMatchResult::default();
+
+        let total_unfilled_amount = tick.limit_order_unfilled_amount()?;
+        if swap_amount == 0 || total_unfilled_amount == 0 {
+            return Ok(result);
+        }
+
+        if is_base_input {
+            if is_fee_on_input {
+                result.amm_fee_amount = swap_amount
+                    .mul_div_ceil((fee_rate).into(), u64::from(FEE_RATE_DENOMINATOR_VALUE))
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+                result.amount_in = swap_amount - result.amm_fee_amount;
+            } else {
+                result.amount_in = swap_amount;
+            }
+            result.amount_out = get_limit_order_output_reference(
+                result.amount_in,
+                tick.tick,
+                swap_direction_zero_for_one,
+            )?;
+            if result.amount_out > total_unfilled_amount {
+                result.amount_out = total_unfilled_amount;
+                result.amount_in = get_limit_order_input_reference(
+                    total_unfilled_amount,
+                    tick.tick,
+                    !swap_direction_zero_for_one,
+                )?;
+                if is_fee_on_input {
+                    result.amm_fee_amount = result
+                        .amount_in
+                        .mul_div_ceil(
+                            (fee_rate).into(),
+                            u64::from(FEE_RATE_DENOMINATOR_VALUE - fee_rate),
+                        )
+                        .ok_or(ErrorCode::CalculateOverflow)?;
+                }
+            }
+        } else {
+            let net_output = swap_amount.min(total_unfilled_amount);
+            result.amount_out = if is_fee_on_input {
+                net_output
+            } else {
+                net_output
+                    .mul_div_ceil(
+                        u64::from(FEE_RATE_DENOMINATOR_VALUE).into(),
+                        (FEE_RATE_DENOMINATOR_VALUE - fee_rate).into(),
+                    )
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .min(total_unfilled_amount)
+            };
+            result.amount_in = get_limit_order_input_reference(
+                result.amount_out,
+                tick.tick,
+                !swap_direction_zero_for_one,
+            )?;
+            if is_fee_on_input {
+                result.amm_fee_amount = result
+                    .amount_in
+                    .mul_div_ceil(
+                        (fee_rate).into(),
+                        u64::from(FEE_RATE_DENOMINATOR_VALUE - fee_rate),
+                    )
+                    .ok_or(ErrorCode::CalculateOverflow)?;
+            }
+        }
+
+        let mut consume_from_part_remaining = 0;
+        if tick.part_filled_orders_remaining > 0 {
+            consume_from_part_remaining = tick.part_filled_orders_remaining.min(result.amount_out);
+            if consume_from_part_remaining > 0 {
+                tick.unfilled_ratio_x64 = U128::from(tick.unfilled_ratio_x64)
+                    .mul_div_floor(
+                        U128::from(tick.part_filled_orders_remaining - consume_from_part_remaining),
+                        U128::from(tick.part_filled_orders_remaining),
+                    )
+                    .ok_or(ErrorCode::CalculateOverflow)?
+                    .as_u128();
+            }
+            tick.part_filled_orders_remaining = tick
+                .part_filled_orders_remaining
+                .saturating_sub(consume_from_part_remaining);
+        }
+        let amount_out_continue_to_consume = result
+            .amount_out
+            .saturating_sub(consume_from_part_remaining);
+
+        if amount_out_continue_to_consume > 0 {
+            require_eq!(tick.part_filled_orders_remaining, 0);
+            require_gte!(
+                tick.orders_amount,
+                amount_out_continue_to_consume,
+                ErrorCode::InvalidLimitOrderAmount
+            );
+            tick.order_phase = tick.order_phase.saturating_add(1);
+
+            tick.unfilled_ratio_x64 = U128::from(fixed_point_64::Q64)
+                .mul_div_floor(
+                    U128::from(tick.orders_amount - amount_out_continue_to_consume),
+                    U128::from(tick.orders_amount),
+                )
+                .ok_or(ErrorCode::CalculateOverflow)?
+                .as_u128();
+
+            tick.part_filled_orders_remaining = tick.orders_amount - amount_out_continue_to_consume;
+            tick.orders_amount = 0;
+        }
+
+        if !is_fee_on_input {
+            result.amm_fee_amount = result
+                .amount_out
+                .mul_div_ceil((fee_rate).into(), u64::from(FEE_RATE_DENOMINATOR_VALUE))
+                .ok_or(ErrorCode::CalculateOverflow)?;
+            result.amount_out = result
+                .amount_out
+                .checked_sub(result.amm_fee_amount)
+                .ok_or(ErrorCode::CalculateOverflow)?;
+        }
+        Ok(result)
+    }
+
+    fn get_price_at_tick_reference(tick: i32, round_up: bool) -> Result<U128> {
+        let token_0_sqrt_price = tick_math::get_sqrt_price_at_tick(tick)?;
+        let token_0_price = if round_up {
+            U128::from(token_0_sqrt_price)
+                .mul_div_ceil(
+                    U128::from(token_0_sqrt_price),
+                    U128::from(fixed_point_64::Q64),
+                )
+                .ok_or(ErrorCode::CalculateOverflow)?
+        } else {
+            U128::from(token_0_sqrt_price)
+                .mul_div_floor(
+                    U128::from(token_0_sqrt_price),
+                    U128::from(fixed_point_64::Q64),
+                )
+                .ok_or(ErrorCode::CalculateOverflow)?
+        };
+        Ok(token_0_price)
+    }
+
+    fn get_limit_order_output_reference(
+        amount_in: u64,
+        tick: i32,
+        zero_for_one: bool,
+    ) -> Result<u64> {
+        let token_0_price_x64 = get_price_at_tick_reference(tick, !zero_for_one)?;
+        let output_amount = if zero_for_one {
+            U128::from(amount_in)
+                .mul_div_floor(token_0_price_x64, U128::from(fixed_point_64::Q64))
+                .ok_or(ErrorCode::CalculateOverflow)?
+                .try_into()
+                .map_err(|_| ErrorCode::CalculateOverflow)?
+        } else {
+            U128::from(amount_in)
+                .mul_div_floor(U128::from(fixed_point_64::Q64), token_0_price_x64)
+                .ok_or(ErrorCode::CalculateOverflow)?
+                .try_into()
+                .map_err(|_| ErrorCode::CalculateOverflow)?
+        };
+        Ok(output_amount)
+    }
+
+    fn get_limit_order_input_reference(
+        amount_out: u64,
+        tick: i32,
+        zero_for_one: bool,
+    ) -> Result<u64> {
+        let token_0_price_x64 = get_price_at_tick_reference(tick, zero_for_one)?;
+        let amount_in = if zero_for_one {
+            U128::from(amount_out)
+                .mul_div_ceil(token_0_price_x64, U128::from(fixed_point_64::Q64))
+                .ok_or(ErrorCode::CalculateOverflow)?
+                .try_into()
+                .map_err(|_| ErrorCode::CalculateOverflow)?
+        } else {
+            U128::from(amount_out)
+                .mul_div_ceil(U128::from(fixed_point_64::Q64), token_0_price_x64)
+                .ok_or(ErrorCode::CalculateOverflow)?
+                .try_into()
+                .map_err(|_| ErrorCode::CalculateOverflow)?
+        };
+        Ok(amount_in)
     }
 
     pub fn build_tick_array_with_tick_states(

--- a/programs/amm/src/states/tick_array.rs
+++ b/programs/amm/src/states/tick_array.rs
@@ -1,6 +1,6 @@
 use crate::error::ErrorCode;
 use crate::libraries::{fixed_point_64, full_math::MulDiv, liquidity_math, tick_math};
-use crate::libraries::{U128, U256};
+use crate::libraries::U128;
 use crate::pool::{RewardInfo, REWARD_NUM};
 use crate::states::config::FEE_RATE_DENOMINATOR_VALUE;
 use crate::util::*;
@@ -432,11 +432,7 @@ impl TickState {
         } else {
             // Convert token1 amount to token0 amount using token1 price (1/token_0_price_x64)
             // token0_amount = token1_amount * 2^64 / token_0_price_x64
-            U128::from(amount_in)
-                .mul_div_floor(U128::from(fixed_point_64::Q64), token_0_price_x64)
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .try_into()
-                .map_err(|_| ErrorCode::CalculateOverflow)?
+            div_u64_shift_left_64_by_u128(amount_in, token_0_price_x64, false)?
         };
         Ok(output_amount)
     }
@@ -461,11 +457,7 @@ impl TickState {
             mul_u64_u128_shift_right_64(amount_out, token_0_price_x64, true)?
         } else {
             // token0_consumed = token1_executed * 2^64 / token_0_price_x64
-            U128::from(amount_out)
-                .mul_div_ceil(U128::from(fixed_point_64::Q64), token_0_price_x64)
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .try_into()
-                .map_err(|_| ErrorCode::CalculateOverflow)?
+            div_u64_shift_left_64_by_u128(amount_out, token_0_price_x64, true)?
         };
         Ok(amount_in)
     }
@@ -527,6 +519,33 @@ impl TickState {
             token_0_sqrt_price_x64,
             !swap_direction_zero_for_one,
         )?;
+
+        self.match_limit_order_with_price(
+            swap_amount,
+            swap_direction_zero_for_one,
+            is_base_input,
+            fee_rate,
+            is_fee_on_input,
+            token_0_price_x64,
+            total_unfilled_amount,
+        )
+    }
+
+    pub fn match_limit_order_with_price(
+        &mut self,
+        swap_amount: u64,
+        swap_direction_zero_for_one: bool,
+        is_base_input: bool,
+        fee_rate: u32,
+        is_fee_on_input: bool,
+        token_0_price_x64: U128,
+        total_unfilled_amount: u64,
+    ) -> Result<LimitOrderMatchResult> {
+        let mut result = LimitOrderMatchResult::default();
+
+        if swap_amount == 0 || total_unfilled_amount == 0 {
+            return Ok(result);
+        }
 
         if is_base_input {
             // Assume the input amount can be fully consumed, calculate the amount of limit order tokens matched
@@ -601,13 +620,11 @@ impl TickState {
             consume_from_part_remaining = self.part_filled_orders_remaining.min(result.amount_out);
             // Update unfilled_ratio: ratio *= (remaining - consumed) / remaining
             if consume_from_part_remaining > 0 {
-                self.unfilled_ratio_x64 = U128::from(self.unfilled_ratio_x64)
-                    .mul_div_floor(
-                        U128::from(self.part_filled_orders_remaining - consume_from_part_remaining),
-                        U128::from(self.part_filled_orders_remaining),
-                    )
-                    .ok_or(ErrorCode::CalculateOverflow)?
-                    .as_u128();
+                self.unfilled_ratio_x64 = mul_u128_u64_div_u64_floor(
+                    self.unfilled_ratio_x64,
+                    self.part_filled_orders_remaining - consume_from_part_remaining,
+                    self.part_filled_orders_remaining,
+                )?;
             }
             self.part_filled_orders_remaining = self
                 .part_filled_orders_remaining
@@ -629,13 +646,11 @@ impl TickState {
             self.order_phase = self.order_phase.saturating_add(1);
 
             // Reset unfilled_ratio for new phase, then update for consumption
-            self.unfilled_ratio_x64 = U128::from(fixed_point_64::Q64)
-                .mul_div_floor(
-                    U128::from(self.orders_amount - amount_out_continue_to_consume),
-                    U128::from(self.orders_amount),
-                )
-                .ok_or(ErrorCode::CalculateOverflow)?
-                .as_u128();
+            self.unfilled_ratio_x64 = mul_u128_u64_div_u64_floor(
+                u128::from(fixed_point_64::Q64),
+                self.orders_amount - amount_out_continue_to_consume,
+                self.orders_amount,
+            )?;
 
             // Move remaining orders_amount to part_filled_orders_remaining
             self.part_filled_orders_remaining = self.orders_amount - amount_out_continue_to_consume;
@@ -665,17 +680,47 @@ impl TickState {
 }
 
 fn mul_u64_u128_shift_right_64(amount: u64, factor_x64: U128, round_up: bool) -> Result<u64> {
-    let product = U256::from(amount) * U256([factor_x64.0[0], factor_x64.0[1], 0, 0]);
-    let mut quotient = product >> fixed_point_64::RESOLUTION;
-    if round_up && product.0[0] != 0 {
+    let low_product = u128::from(amount) * u128::from(factor_x64.0[0]);
+    let high_product = u128::from(amount) * u128::from(factor_x64.0[1]);
+    let mut quotient = high_product
+        .checked_add(low_product >> fixed_point_64::RESOLUTION)
+        .ok_or(ErrorCode::CalculateOverflow)?;
+    if round_up && (low_product & (u128::from(fixed_point_64::Q64) - 1)) != 0 {
         quotient = quotient
-            .checked_add(U256::from(1u8))
+            .checked_add(1)
             .ok_or(ErrorCode::CalculateOverflow)?;
     }
-    if quotient.0[1] != 0 || quotient.0[2] != 0 || quotient.0[3] != 0 {
+    quotient
+        .try_into()
+        .map_err(|_| ErrorCode::CalculateOverflow.into())
+}
+
+fn div_u64_shift_left_64_by_u128(amount: u64, divisor_x64: U128, round_up: bool) -> Result<u64> {
+    let divisor = divisor_x64.as_u128();
+    if divisor == 0 {
         return Err(ErrorCode::CalculateOverflow.into());
     }
-    Ok(quotient.0[0])
+
+    let numerator = u128::from(amount) << fixed_point_64::RESOLUTION;
+    let mut quotient = numerator / divisor;
+    if round_up && numerator % divisor != 0 {
+        quotient = quotient
+            .checked_add(1)
+            .ok_or(ErrorCode::CalculateOverflow)?;
+    }
+    quotient
+        .try_into()
+        .map_err(|_| ErrorCode::CalculateOverflow.into())
+}
+
+fn mul_u128_u64_div_u64_floor(value: u128, multiplier: u64, divisor: u64) -> Result<u128> {
+    if divisor == 0 {
+        return Err(ErrorCode::CalculateOverflow.into());
+    }
+    value
+        .checked_mul(u128::from(multiplier))
+        .map(|product| product / u128::from(divisor))
+        .ok_or(ErrorCode::CalculateOverflow.into())
 }
 
 // Calculates the fee growths inside of tick_lower and tick_upper based on their positions relative to tick_current.
@@ -819,6 +864,158 @@ pub mod tick_array_test {
             mul_u64_u128_shift_right_64(1, U128::from(fixed_point_64::Q64 + 1), true).unwrap(),
             2
         );
+    }
+
+    #[test]
+    fn native_limit_order_math_matches_generic_mul_div() {
+        let amounts = [
+            0,
+            1,
+            7,
+            1_000,
+            u32::MAX as u64,
+            u64::MAX / 2,
+            u64::MAX,
+        ];
+        let factors = [
+            U128::from(1),
+            U128::from(fixed_point_64::Q64 - 1),
+            U128::from(fixed_point_64::Q64),
+            U128::from(fixed_point_64::Q64 + 1),
+            U128([1, 1]),
+            U128([u64::MAX, 1]),
+            U128([0, u64::MAX / 2]),
+        ];
+
+        for amount in amounts {
+            for factor in factors {
+                for round_up in [false, true] {
+                    let expected = if round_up {
+                        U128::from(amount)
+                            .mul_div_ceil(factor, U128::from(fixed_point_64::Q64))
+                    } else {
+                        U128::from(amount)
+                            .mul_div_floor(factor, U128::from(fixed_point_64::Q64))
+                    }
+                    .ok_or(ErrorCode::CalculateOverflow)
+                    .and_then(|value| {
+                        value
+                            .try_into()
+                            .map_err(|_| ErrorCode::CalculateOverflow)
+                    });
+
+                    assert!(
+                        same_u64_result(
+                            mul_u64_u128_shift_right_64(amount, factor, round_up),
+                            expected
+                        ),
+                        "amount={amount} factor={factor:?} round_up={round_up}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn native_inverse_limit_order_math_matches_generic_mul_div() {
+        let amounts = [
+            0,
+            1,
+            7,
+            1_000,
+            u32::MAX as u64,
+            u64::MAX / 2,
+            u64::MAX,
+        ];
+        let divisors = [
+            U128::from(1),
+            U128::from(fixed_point_64::Q64 - 1),
+            U128::from(fixed_point_64::Q64),
+            U128::from(fixed_point_64::Q64 + 1),
+            U128([1, 1]),
+            U128([u64::MAX, 1]),
+            U128([0, u64::MAX / 2]),
+        ];
+
+        for amount in amounts {
+            for divisor in divisors {
+                for round_up in [false, true] {
+                    let expected = if round_up {
+                        U128::from(amount)
+                            .mul_div_ceil(U128::from(fixed_point_64::Q64), divisor)
+                    } else {
+                        U128::from(amount)
+                            .mul_div_floor(U128::from(fixed_point_64::Q64), divisor)
+                    }
+                    .ok_or(ErrorCode::CalculateOverflow)
+                    .and_then(|value| {
+                        value
+                            .try_into()
+                            .map_err(|_| ErrorCode::CalculateOverflow)
+                    });
+
+                    assert!(
+                        same_u64_result(
+                            div_u64_shift_left_64_by_u128(amount, divisor, round_up),
+                            expected
+                        ),
+                        "amount={amount} divisor={divisor:?} round_up={round_up}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn native_unfilled_ratio_math_matches_generic_mul_div() {
+        let ratios = [
+            0,
+            1,
+            u128::from(fixed_point_64::Q64 / 2),
+            u128::from(fixed_point_64::Q64),
+        ];
+        let multipliers = [0, 1, 7, u32::MAX as u64, u64::MAX];
+        let divisors = [1, 2, 7, u32::MAX as u64, u64::MAX];
+
+        for ratio in ratios {
+            for multiplier in multipliers {
+                for divisor in divisors {
+                    let expected = U128::from(ratio)
+                        .mul_div_floor(U128::from(multiplier), U128::from(divisor))
+                        .ok_or(ErrorCode::CalculateOverflow)
+                        .map(|value| value.as_u128());
+                    assert!(
+                        same_u128_result(
+                            mul_u128_u64_div_u64_floor(ratio, multiplier, divisor),
+                            expected
+                        ),
+                        "ratio={ratio} multiplier={multiplier} divisor={divisor}"
+                    );
+                }
+            }
+        }
+    }
+
+    fn same_u64_result<LeftError, RightError>(
+        left: std::result::Result<u64, LeftError>,
+        right: std::result::Result<u64, RightError>,
+    ) -> bool {
+        match (left, right) {
+            (Ok(left), Ok(right)) => left == right,
+            (Err(_), Err(_)) => true,
+            _ => false,
+        }
+    }
+
+    fn same_u128_result<LeftError, RightError>(
+        left: std::result::Result<u128, LeftError>,
+        right: std::result::Result<u128, RightError>,
+    ) -> bool {
+        match (left, right) {
+            (Ok(left), Ok(right)) => left == right,
+            (Err(_), Err(_)) => true,
+            _ => false,
+        }
     }
 
     #[derive(Clone, Copy)]

--- a/programs/amm/src/util/system.rs
+++ b/programs/amm/src/util/system.rs
@@ -1,4 +1,4 @@
-use anchor_lang::{prelude::*, system_program};
+use anchor_lang::prelude::*;
 use anchor_lang::solana_program::{program::invoke_signed, system_instruction};
 
 pub fn create_or_allocate_account<'a>(
@@ -32,7 +32,11 @@ pub fn create_or_allocate_account<'a>(
             let ix = system_instruction::transfer(payer.key, target_account.key, required_lamports);
             invoke_signed(
                 &ix,
-                &[payer.clone(), target_account.clone(), system_program.clone()],
+                &[
+                    payer.clone(),
+                    target_account.clone(),
+                    system_program.clone(),
+                ],
                 &[],
             )?;
         }


### PR DESCRIPTION
## Summary

- Precompute reusable Raydium CLMM quote-step data from account state during tick-array cache rebuild.
- Use cached full-step CLMM range amounts in the quote path when the cached context exactly matches the live step.
- Keep quote behavior fundamental: no quote-result cache, no precision relaxation.
- Cache use is guarded by current sqrt price, target sqrt price, liquidity, and swap direction; mismatches fall back to the original math.

## Why

The flamegraph showed the hot quote path spending most time in repeated CLMM range math: `compute_swap`, `get_delta_amount_*_unsigned`, `U256::mul_div_*`, and `U512::div_mod`. Limit-order matching itself was not the dominant flat cost. This PR moves the reusable full-step amount calculation to update/cache-build time so quote can skip repeated big-number math for full tick steps.

## Benchmark

Measured through the stacked Jupiter benchmark PR using `raydium_clmm_limit_order/hnhp-usdc-cards-exact-in-large`:

```text
before radical cache: [856.10 ns 865.33 ns 875.68 ns]
after this SDK PR:   [380.34 ns 380.61 ns 380.89 ns]
```

That is roughly a 56% latency reduction for the stressed large reverse limit-order quote case, and it reaches the sub-400ns target locally.

## Validation

- `cargo test --workspace --all-targets` in `raydium-clmm`: `65 passed`
- Jupiter stacked integration: `cargo check --release -p jupiter-core --bench raydium_clmm_limit_order`
- Focused Jupiter benchmark after cleanup: `[380.34 ns 380.61 ns 380.89 ns]`
- Jupiter quote/simulation harness: Raydium quote matched simulated on-chain output for the exercised failing snapshot case; remaining Jupiter full-test failures are known insta snapshot assertions.
